### PR TITLE
Fix web dependency and theme API usage

### DIFF
--- a/lib/core/themes/app_theme.dart
+++ b/lib/core/themes/app_theme.dart
@@ -111,7 +111,7 @@ class AppTheme {
       ),
 
       // Cards
-      cardTheme: CardTheme(
+      cardTheme: CardThemeData(
         color: cardColor,
         elevation: 2,
         shape: RoundedRectangleBorder(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,3 +68,6 @@ flutter:
     - assets/icons/
     - assets/animations/
 
+dependency_overrides:
+  web: ^0.5.0
+

--- a/pubspec_web.yaml
+++ b/pubspec_web.yaml
@@ -68,3 +68,6 @@ flutter:
     - assets/icons/
     - assets/animations/
 
+dependency_overrides:
+  web: ^0.5.0
+


### PR DESCRIPTION
## Summary
- override the outdated `web` package with a Dart 3 compatible version
- update `AppTheme` to use `CardThemeData` for newer Flutter versions

## Testing
- ❌ `flutter analyze` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68518ac50950832fbb3e75c1045cb448