### PR TITLE
Add price interface

### DIFF
--- a/lib/presentation/pages/home/home_page.dart
+++ b/lib/presentation/pages/home/home_page.dart
@@ -7,6 +7,7 @@ import '../map/map_page.dart';
 import '../search/search_page.dart';
 import '../shopping_list/shopping_lists_page.dart';
 import '../profile/profile_page.dart';
+import '../price/add_price_page.dart';
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
@@ -183,8 +184,11 @@ class AddPriceBottomSheet extends StatelessWidget {
             subtitle: const Text('Digite o preço manualmente'),
             onTap: () {
               Navigator.pop(context);
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Funcionalidade em desenvolvimento')),
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const AddPricePage(),
+                ),
               );
             },
           ),

--- a/lib/presentation/pages/price/add_price_page.dart
+++ b/lib/presentation/pages/price/add_price_page.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/utils/validators.dart';
+
+class AddPricePage extends StatefulWidget {
+  const AddPricePage({super.key});
+
+  @override
+  State<AddPricePage> createState() => _AddPricePageState();
+}
+
+class _AddPricePageState extends State<AddPricePage> {
+  final _formKey = GlobalKey<FormState>();
+  final _productController = TextEditingController();
+  final _storeController = TextEditingController();
+  final _priceController = TextEditingController();
+
+  @override
+  void dispose() {
+    _productController.dispose();
+    _storeController.dispose();
+    _priceController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Preço salvo (apenas interface)')),
+      );
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Novo Preço'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(AppTheme.paddingLarge),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                controller: _productController,
+                decoration: const InputDecoration(
+                  labelText: 'Produto',
+                  prefixIcon: Icon(Icons.shopping_basket),
+                ),
+                validator: Validators.validateProductName,
+              ),
+              const SizedBox(height: AppTheme.paddingMedium),
+              TextFormField(
+                controller: _storeController,
+                decoration: const InputDecoration(
+                  labelText: 'Estabelecimento',
+                  prefixIcon: Icon(Icons.store),
+                ),
+                validator: Validators.validateStoreName,
+              ),
+              const SizedBox(height: AppTheme.paddingMedium),
+              TextFormField(
+                controller: _priceController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(
+                  labelText: 'Preço',
+                  prefixIcon: Icon(Icons.attach_money),
+                ),
+                validator: Validators.validatePrice,
+              ),
+              const SizedBox(height: AppTheme.paddingLarge),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _submit,
+                  child: const Text('Salvar'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create page for inserting a price manually
- hook up the Add Price bottom sheet to open the new page

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851905af440832f9a8c92b3b346fbd9