### PR TITLE
Add admin role features

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -22,6 +22,9 @@ class AppConstants {
   static const int pointsForStoreSubmission = 15;
   static const int pointsForProductSubmission = 5;
   static const int pointsForReview = 2;
+
+  // Contas de administrador
+  static const List<String> adminEmails = ['admin@precinho.com'];
   
   // Configurações de validação
   static const int minPasswordLength = 6;

--- a/lib/data/datasources/auth_service.dart
+++ b/lib/data/datasources/auth_service.dart
@@ -3,6 +3,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 import '../models/user_model.dart';
 import '../../core/errors/failures.dart';
 import '../../core/constants/enums.dart';
+import '../../core/constants/app_constants.dart';
 
 abstract class AuthService {
   Future<UserModel?> getCurrentUser();
@@ -168,13 +169,18 @@ class FirebaseAuthService implements AuthService {
   }
 
   UserModel _mapFirebaseUserToUserModel(firebase_auth.User firebaseUser) {
+    final email = firebaseUser.email;
+    final role = email != null && AppConstants.adminEmails.contains(email)
+        ? UserRole.admin
+        : UserRole.user;
+
     return UserModel(
       id: firebaseUser.uid,
       name: firebaseUser.displayName ?? 'Usuário',
-      email: firebaseUser.email ?? '',
+      email: email ?? '',
       photoUrl: firebaseUser.photoURL,
       points: 0, // Será obtido do Firestore
-      role: UserRole.user,
+      role: role,
       createdAt: firebaseUser.metadata.creationTime ?? DateTime.now(),
       updatedAt: DateTime.now(),
       isActive: true,

--- a/lib/domain/entities/user.dart
+++ b/lib/domain/entities/user.dart
@@ -64,6 +64,9 @@ class User extends Equatable {
     );
   }
 
+  bool get isAdmin => role == UserRole.admin;
+  bool get isModerator => role == UserRole.moderator;
+
   @override
   List<Object?> get props => [
         id,

--- a/lib/presentation/pages/admin/add_product_page.dart
+++ b/lib/presentation/pages/admin/add_product_page.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/constants/enums.dart';
+import '../../../core/utils/validators.dart';
+
+class AddProductPage extends StatefulWidget {
+  const AddProductPage({super.key});
+
+  @override
+  State<AddProductPage> createState() => _AddProductPageState();
+}
+
+class _AddProductPageState extends State<AddProductPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _brandController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  ProductCategory? _category;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _brandController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Produto cadastrado (apenas interface)')),
+      );
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Novo Produto'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(AppTheme.paddingLarge),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  labelText: 'Nome',
+                  prefixIcon: Icon(Icons.shopping_bag),
+                ),
+                validator: Validators.validateProductName,
+              ),
+              const SizedBox(height: AppTheme.paddingMedium),
+              TextFormField(
+                controller: _brandController,
+                decoration: const InputDecoration(
+                  labelText: 'Marca',
+                  prefixIcon: Icon(Icons.business),
+                ),
+                validator: Validators.validateProductName,
+              ),
+              const SizedBox(height: AppTheme.paddingMedium),
+              DropdownButtonFormField<ProductCategory>(
+                value: _category,
+                decoration: const InputDecoration(labelText: 'Categoria'),
+                items: ProductCategory.values.map((category) {
+                  return DropdownMenuItem(
+                    value: category,
+                    child: Text(category.displayName),
+                  );
+                }).toList(),
+                onChanged: (value) {
+                  setState(() {
+                    _category = value;
+                  });
+                },
+                validator: (value) =>
+                    value == null ? 'Selecione uma categoria' : null,
+              ),
+              const SizedBox(height: AppTheme.paddingMedium),
+              TextFormField(
+                controller: _descriptionController,
+                maxLines: 3,
+                decoration: const InputDecoration(
+                  labelText: 'Descrição',
+                  alignLabelWithHint: true,
+                ),
+                validator: Validators.validateDescription,
+              ),
+              const SizedBox(height: AppTheme.paddingLarge),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _submit,
+                  child: const Text('Salvar'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/admin/admin_home_page.dart
+++ b/lib/presentation/pages/admin/admin_home_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import '../../../core/themes/app_theme.dart';
+import 'add_product_page.dart';
+import 'validate_prices_page.dart';
+
+class AdminHomePage extends StatelessWidget {
+  const AdminHomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Painel Administrativo'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(AppTheme.paddingLarge),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const AddProductPage(),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.add),
+              label: const Text('Adicionar Produto'),
+            ),
+            const SizedBox(height: AppTheme.paddingMedium),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const ValidatePricesPage(),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.check),
+              label: const Text('Validar Preços'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/admin/validate_prices_page.dart
+++ b/lib/presentation/pages/admin/validate_prices_page.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import '../../../core/themes/app_theme.dart';
+
+class ValidatePricesPage extends StatelessWidget {
+  const ValidatePricesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Validar Preços'),
+      ),
+      body: ListView.builder(
+        itemCount: 5,
+        padding: const EdgeInsets.all(AppTheme.paddingMedium),
+        itemBuilder: (context, index) {
+          return Card(
+            margin: const EdgeInsets.only(bottom: AppTheme.paddingSmall),
+            child: ListTile(
+              leading: const Icon(
+                Icons.local_offer,
+                color: AppTheme.primaryColor,
+              ),
+              title: Text('Preço ${index + 1}'),
+              subtitle: const Text('Aguardando validação'),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.check, color: Colors.green),
+                    onPressed: () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content:
+                              Text('Preço aprovado (apenas interface)'),
+                        ),
+                      );
+                    },
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close, color: Colors.red),
+                    onPressed: () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content:
+                              Text('Preço rejeitado (apenas interface)'),
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
 import '../../providers/auth_provider.dart';
+import '../admin/admin_home_page.dart';
 
 class ProfilePage extends ConsumerWidget {
   const ProfilePage({super.key});
@@ -256,6 +257,23 @@ class ProfilePage extends ConsumerWidget {
             // TODO: Navegar para ranking
           },
         ),
+
+        // Painel administrativo (apenas para admins)
+        if (ref.watch(isAdminProvider))
+          _buildMenuItem(
+            context,
+            'Painel Administrativo',
+            'Gerencie produtos e preços',
+            Icons.admin_panel_settings,
+            () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const AdminHomePage(),
+                ),
+              );
+            },
+          ),
 
         // Configurações
         _buildMenuItem(

--- a/lib/presentation/providers/auth_provider.dart
+++ b/lib/presentation/providers/auth_provider.dart
@@ -217,6 +217,12 @@ final currentUserProvider = Provider<UserModel?>((ref) {
   return authState.user;
 });
 
+// Provider para verificar se o usuário é administrador
+final isAdminProvider = Provider<bool>((ref) {
+  final user = ref.watch(currentUserProvider);
+  return user?.role == UserRole.admin;
+});
+
 // Provider para verificar se está carregando
 final isLoadingProvider = Provider<bool>((ref) {
   final authState = ref.watch(authNotifierProvider);


### PR DESCRIPTION
## Summary
- enable recognizing admin emails via new constant
- map admin role when signing in
- expose isAdminProvider to check privileges
- add admin panel and pages for adding products and validating prices
- show admin panel in profile when user has admin role

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851920208ec832fac9e4175701f07d2