### PR TITLE
Implement admin product management with Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ class Price {
 - [x] Gerenciamento de estado com Riverpod
 - [x] Tema e design system
 - [x] Validações e formatadores
+- [x] Página de administração com gestão de produtos via Firestore
 
 ### 🚧 Em Desenvolvimento
 - [ ] Integração com Google Maps

--- a/lib/presentation/pages/admin/add_product_page.dart
+++ b/lib/presentation/pages/admin/add_product_page.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/constants/enums.dart';
@@ -25,12 +26,21 @@ class _AddProductPageState extends State<AddProductPage> {
     super.dispose();
   }
 
-  void _submit() {
+  Future<void> _submit() async {
     if (_formKey.currentState!.validate()) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Produto cadastrado (apenas interface)')),
-      );
-      Navigator.pop(context);
+      await FirebaseFirestore.instance.collection('products').add({
+        'name': _nameController.text.trim(),
+        'brand': _brandController.text.trim(),
+        'description': _descriptionController.text.trim(),
+        'category': _category?.value,
+        'created_at': Timestamp.now(),
+      });
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Produto cadastrado')), 
+        );
+        Navigator.pop(context); 
+      }
     }
   }
 

--- a/lib/presentation/pages/admin/admin_home_page.dart
+++ b/lib/presentation/pages/admin/admin_home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../../core/themes/app_theme.dart';
 import 'add_product_page.dart';
+import 'manage_products_page.dart';
 import 'validate_prices_page.dart';
 
 class AdminHomePage extends StatelessWidget {
@@ -28,6 +29,19 @@ class AdminHomePage extends StatelessWidget {
               },
               icon: const Icon(Icons.add),
               label: const Text('Adicionar Produto'),
+            ),
+            const SizedBox(height: AppTheme.paddingMedium),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const ManageProductsPage(),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.list),
+              label: const Text('Gerenciar Produtos'),
             ),
             const SizedBox(height: AppTheme.paddingMedium),
             ElevatedButton.icon(

--- a/lib/presentation/pages/admin/manage_products_page.dart
+++ b/lib/presentation/pages/admin/manage_products_page.dart
@@ -1,0 +1,86 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import '../../../core/themes/app_theme.dart';
+import 'add_product_page.dart';
+
+class ManageProductsPage extends StatelessWidget {
+  const ManageProductsPage({super.key});
+
+  Future<void> _deleteProduct(BuildContext context, DocumentReference doc) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Excluir Produto'),
+        content: const Text('Tem certeza que deseja excluir este produto?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Excluir'),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      await doc.delete();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Produto exclu\u00eddo')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Gerenciar Produtos'),
+      ),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('products')
+            .orderBy('name')
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return const Center(child: Text('Erro ao carregar produtos'));
+          }
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('Nenhum produto cadastrado'));
+          }
+          return ListView.builder(
+            itemCount: docs.length,
+            itemBuilder: (context, index) {
+              final doc = docs[index];
+              final data = doc.data() as Map<String, dynamic>;
+              return ListTile(
+                leading: const Icon(Icons.shopping_bag, color: AppTheme.primaryColor),
+                title: Text(data['name'] ?? ''),
+                subtitle: Text(data['brand'] ?? ''),
+                trailing: IconButton(
+                  icon: const Icon(Icons.delete, color: AppTheme.errorColor),
+                  onPressed: () => _deleteProduct(context, doc.reference),
+                ),
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const AddProductPage()),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow adding products to Firestore
- list and delete products from ManageProductsPage
- link ManageProductsPage from AdminHomePage
- document admin page in README

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851970174a0832fadd08d3ac24f618d