### PR TITLE
Fix missing LoadingState import

### DIFF
--- a/lib/presentation/pages/auth/register_page.dart
+++ b/lib/presentation/pages/auth/register_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/validators.dart';
+import '../../../core/constants/enums.dart';
 import '../../providers/auth_provider.dart';
 
 class RegisterPage extends ConsumerStatefulWidget {

--- a/lib/presentation/pages/auth/register_page_web.dart
+++ b/lib/presentation/pages/auth/register_page_web.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/validators.dart';
+import '../../../core/constants/enums.dart';
 import '../../providers/auth_provider_web.dart';
 
 class RegisterPageWeb extends ConsumerStatefulWidget {


### PR DESCRIPTION
## Summary
- import enums where needed on registration pages

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c8f5ec20832fa116f84b7c40c8f7