### PR TITLE
Add Firebase request logging

### DIFF
--- a/lib/core/logging/firebase_logger.dart
+++ b/lib/core/logging/firebase_logger.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+
+/// Simple logger for Firebase operations.
+class FirebaseLogger {
+  /// Logs [message] with optional [data] in debug mode.
+  static void log(String message, [Map<String, dynamic>? data]) {
+    if (kDebugMode) {
+      final buffer = StringBuffer('[Firebase] $message');
+      if (data != null) buffer.write(' | Data: $data');
+      // ignore: avoid_print
+      print(buffer.toString());
+    }
+  }
+}

--- a/lib/presentation/pages/admin/add_product_page.dart
+++ b/lib/presentation/pages/admin/add_product_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/constants/enums.dart';
 import '../../../core/utils/validators.dart';
+import '../../../core/logging/firebase_logger.dart';
 
 class AddProductPage extends StatefulWidget {
   const AddProductPage({super.key});
@@ -29,13 +30,16 @@ class _AddProductPageState extends State<AddProductPage> {
   Future<void> _submit() async {
     if (_formKey.currentState!.validate()) {
       try {
-        await FirebaseFirestore.instance.collection('products').add({
+        final data = {
           'name': _nameController.text.trim(),
           'brand': _brandController.text.trim(),
           'description': _descriptionController.text.trim(),
           'category': _category?.value,
           'created_at': Timestamp.now(),
-        });
+        };
+        FirebaseLogger.log('Adding product', data);
+        await FirebaseFirestore.instance.collection('products').add(data);
+        FirebaseLogger.log('Product added', {'name': data['name']});
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Produto cadastrado')),
@@ -43,6 +47,7 @@ class _AddProductPageState extends State<AddProductPage> {
           Navigator.pop(context);
         }
       } catch (e) {
+        FirebaseLogger.log('Add product error', {'error': e.toString()});
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(

--- a/lib/presentation/pages/admin/manage_products_page.dart
+++ b/lib/presentation/pages/admin/manage_products_page.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import '../../../core/themes/app_theme.dart';
 import 'add_product_page.dart';
+import '../../../core/logging/firebase_logger.dart';
 
 class ManageProductsPage extends StatelessWidget {
   const ManageProductsPage({super.key});
@@ -25,7 +26,9 @@ class ManageProductsPage extends StatelessWidget {
       ),
     );
     if (confirm == true) {
+      FirebaseLogger.log('Deleting product', {'path': doc.path});
       await doc.delete();
+      FirebaseLogger.log('Product deleted', {'path': doc.path});
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Produto exclu\u00eddo')),
       );
@@ -46,6 +49,10 @@ class ManageProductsPage extends StatelessWidget {
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasData) {
+            FirebaseLogger.log('Products snapshot',
+                {'count': snapshot.data!.docs.length});
           }
           if (snapshot.hasError) {
             return const Center(child: Text('Erro ao carregar produtos'));

--- a/lib/presentation/pages/price/add_price_page.dart
+++ b/lib/presentation/pages/price/add_price_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
 import '../../../core/utils/validators.dart';
+import '../../../core/logging/firebase_logger.dart';
 
 class AddPricePage extends StatefulWidget {
   const AddPricePage({super.key});
@@ -30,12 +31,15 @@ class _AddPricePageState extends State<AddPricePage> {
       final priceValue = Formatters.parsePrice(_priceController.text.trim());
 
       try {
-        await FirebaseFirestore.instance.collection('prices').add({
+        final data = {
           'product': _productController.text.trim(),
           'store': _storeController.text.trim(),
           'price': priceValue,
           'created_at': Timestamp.now(),
-        });
+        };
+        FirebaseLogger.log('Adding price', data);
+        await FirebaseFirestore.instance.collection('prices').add(data);
+        FirebaseLogger.log('Price added', {'product': data['product']});
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Preço salvo')),
@@ -43,6 +47,7 @@ class _AddPricePageState extends State<AddPricePage> {
           Navigator.pop(context);
         }
       } catch (e) {
+        FirebaseLogger.log('Add price error', {'error': e.toString()});
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(


### PR DESCRIPTION
## Summary
- create `FirebaseLogger`
- log Firestore operations in add price/product pages
- log product deletion and snapshot counts
- log authentication actions in `AuthService`

## Testing
- `dart format lib/core/logging/firebase_logger.dart lib/presentation/pages/price/add_price_page.dart lib/presentation/pages/admin/add_product_page.dart lib/presentation/pages/admin/manage_products_page.dart lib/data/datasources/auth_service.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851ca822d7c832f9e8e3e1ef7a090ec