### PR TITLE
Add user admin page

### DIFF
--- a/lib/presentation/pages/admin/admin_home_page.dart
+++ b/lib/presentation/pages/admin/admin_home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../../core/themes/app_theme.dart';
 import 'add_product_page.dart';
 import 'manage_products_page.dart';
+import 'manage_users_page.dart';
 import 'validate_prices_page.dart';
 
 class AdminHomePage extends StatelessWidget {
@@ -42,6 +43,19 @@ class AdminHomePage extends StatelessWidget {
               },
               icon: const Icon(Icons.list),
               label: const Text('Gerenciar Produtos'),
+            ),
+            const SizedBox(height: AppTheme.paddingMedium),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const ManageUsersPage(),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.people),
+              label: const Text('Gerenciar Usuários'),
             ),
             const SizedBox(height: AppTheme.paddingMedium),
             ElevatedButton.icon(

--- a/lib/presentation/pages/admin/manage_users_page.dart
+++ b/lib/presentation/pages/admin/manage_users_page.dart
@@ -1,0 +1,141 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/constants/enums.dart';
+import '../../../core/logging/firebase_logger.dart';
+
+class ManageUsersPage extends StatelessWidget {
+  const ManageUsersPage({super.key});
+
+  Future<void> _toggleActive(
+    BuildContext context,
+    DocumentReference doc,
+    bool isActive,
+  ) async {
+    try {
+      final newValue = !isActive;
+      FirebaseLogger.log('Updating user active', {
+        'path': doc.path,
+        'is_active': newValue,
+      });
+      await doc.update({'is_active': newValue});
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            newValue ? 'Usuário desbloqueado' : 'Usuário bloqueado',
+          ),
+        ),
+      );
+    } catch (e) {
+      FirebaseLogger.log('Toggle active error', {'error': e.toString()});
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Erro ao atualizar usuário: $e'),
+          backgroundColor: AppTheme.errorColor,
+        ),
+      );
+    }
+  }
+
+  Future<void> _toggleAdmin(
+    BuildContext context,
+    DocumentReference doc,
+    String role,
+  ) async {
+    try {
+      final newRole =
+          role == UserRole.admin.value ? UserRole.user.value : UserRole.admin.value;
+      FirebaseLogger.log('Updating user role', {
+        'path': doc.path,
+        'role': newRole,
+      });
+      await doc.update({'role': newRole});
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            newRole == UserRole.admin.value
+                ? 'Usuário agora é administrador'
+                : 'Usuário não é mais administrador',
+          ),
+        ),
+      );
+    } catch (e) {
+      FirebaseLogger.log('Toggle role error', {'error': e.toString()});
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Erro ao atualizar usuário: $e'),
+          backgroundColor: AppTheme.errorColor,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Gerenciar Usuários'),
+      ),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('users')
+            .orderBy('name')
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return const Center(child: Text('Erro ao carregar usuários'));
+          }
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('Nenhum usuário encontrado'));
+          }
+          return ListView.builder(
+            itemCount: docs.length,
+            itemBuilder: (context, index) {
+              final doc = docs[index];
+              final data = doc.data() as Map<String, dynamic>;
+              final isActive = data['is_active'] as bool? ?? true;
+              final role = data['role'] as String? ?? UserRole.user.value;
+              return ListTile(
+                leading: const Icon(Icons.person, color: AppTheme.primaryColor),
+                title: Text(data['name'] ?? ''),
+                subtitle: Text(data['email'] ?? ''),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: Icon(
+                        isActive ? Icons.block : Icons.check_circle,
+                        color: isActive
+                            ? AppTheme.errorColor
+                            : AppTheme.successColor,
+                      ),
+                      onPressed: () =>
+                          _toggleActive(context, doc.reference, isActive),
+                    ),
+                    IconButton(
+                      icon: Icon(
+                        role == UserRole.admin.value
+                            ? Icons.admin_panel_settings
+                            : Icons.admin_panel_settings_outlined,
+                        color: role == UserRole.admin.value
+                            ? AppTheme.warningColor
+                            : AppTheme.primaryColor,
+                      ),
+                      onPressed: () =>
+                          _toggleAdmin(context, doc.reference, role),
+                    ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add page to manage users in Firestore
- link ManageUsersPage from AdminHomePage

## Testing
- `dart` was not available so formatting or analyzer couldn't run

------
https://chatgpt.com/codex/tasks/task_e_6851ead97afc832f9ef94229b3a02154