### PR TITLE
Add photo field to product registration

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   # geolocator: ^10.1.0
   # geocoding: ^2.1.1
   # camera: ^0.10.5+5
-  # image_picker: ^1.0.4
+  image_picker: ^1.0.4
   # google_maps_flutter: ^2.5.0
   # google_mlkit_text_recognition: ^0.10.0
   # permission_handler: ^11.1.0

--- a/pubspec_web.yaml
+++ b/pubspec_web.yaml
@@ -49,7 +49,7 @@ dependencies:
   # geolocator: ^10.1.0
   # geocoding: ^2.1.1
   # camera: ^0.10.5+5
-  # image_picker: ^1.0.4
+  image_picker: ^1.0.4
   # google_maps_flutter: ^2.5.0
   # google_mlkit_text_recognition: ^0.10.0
   # permission_handler: ^11.1.0


### PR DESCRIPTION
## Summary
- allow selecting an image when creating products
- store uploaded photo URL in Firestore
- enable `image_picker` in project configs

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520b4e2f1c832faff1dd84a0e17f63