### PR TITLE
Fix mobile web meta tag

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -21,7 +21,7 @@
   <meta name="description" content="Precinho - Encontre os melhores preços de supermercado">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Precinho">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">


### PR DESCRIPTION
## Summary
- fix deprecated web app capability meta tag in `web/index.html`

## Testing
- `flutter test` *(fails: `bash: flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68521db3515c832fb436049700bf5542