### PR TITLE
Add Google Sign-In setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ flutter pub get
 4. **Configure as APIs:**
    - Google Maps API Key
    - Google Sign-In (se necessário)
+     - Para autenticação na web é preciso adicionar o *client ID* do tipo **Web application** no arquivo `web/index.html`:
+
+       ```html
+       <meta name="google-signin-client_id" content="YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com">
+       ```
+
+       Substitua `YOUR_GOOGLE_CLIENT_ID` pelo ID gerado no Google Cloud Console.
 
 5. **Execute a aplicação:**
 ```bash

--- a/web/index.html
+++ b/web/index.html
@@ -20,6 +20,10 @@
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Precinho - Encontre os melhores preços de supermercado">
 
+  <!-- Google Sign-In client ID (necessário para autenticação Web) -->
+  <!-- Substitua o valor abaixo pelo client ID gerado no Google Cloud Console -->
+  <meta name="google-signin-client_id" content="YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com">
+
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">


### PR DESCRIPTION
## Summary
- clarify Google Sign-In setup in README
- include google-signin client ID meta tag in web/index.html

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852207a4a90832f9a5a2fb4c6e05fcc