### PR TITLE
Add store search feature

### DIFF
--- a/lib/presentation/pages/search/search_page.dart
+++ b/lib/presentation/pages/search/search_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/constants/enums.dart';
+import '../store/store_search_page.dart';
 
 class SearchPage extends ConsumerStatefulWidget {
   const SearchPage({super.key});
@@ -26,6 +27,19 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Buscar Preços'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.store),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const StoreSearchPage(),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: Column(
         children: [

--- a/lib/presentation/pages/store/store_detail_page.dart
+++ b/lib/presentation/pages/store/store_detail_page.dart
@@ -1,0 +1,74 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/themes/app_theme.dart';
+import '../../providers/store_favorites_provider.dart';
+
+class StoreDetailPage extends ConsumerWidget {
+  final DocumentSnapshot store;
+  const StoreDetailPage({required this.store, super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final data = store.data() as Map<String, dynamic>;
+    final isFav = ref.watch(storeFavoritesProvider).contains(store.id);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(data['name'] ?? 'Estabelecimento'),
+        actions: [
+          IconButton(
+            icon: Icon(
+              isFav ? Icons.star : Icons.star_border,
+              color: isFav ? Colors.amber : AppTheme.textOnPrimaryColor,
+            ),
+            onPressed: () {
+              ref.read(storeFavoritesProvider.notifier).toggleFavorite(store.id);
+            },
+          ),
+        ],
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(AppTheme.paddingMedium),
+            child: Text(data['address'] ?? ''),
+          ),
+          const Divider(),
+          Expanded(
+            child: StreamBuilder<QuerySnapshot>(
+              stream: FirebaseFirestore.instance
+                  .collection('prices')
+                  .where('store', isEqualTo: data['name'])
+                  .snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final docs = snapshot.data?.docs ?? [];
+                if (docs.isEmpty) {
+                  return const Center(child: Text('Nenhum preço para este estabelecimento'));
+                }
+                return ListView.builder(
+                  itemCount: docs.length,
+                  itemBuilder: (context, index) {
+                    final priceData = docs[index].data() as Map<String, dynamic>;
+                    return ListTile(
+                      title: Text(priceData['product'] ?? ''),
+                      trailing: Text(
+                        'R\$ ${(priceData['price'] as num).toStringAsFixed(2)}',
+                        style: AppTheme.priceTextStyle,
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/store/store_search_page.dart
+++ b/lib/presentation/pages/store/store_search_page.dart
@@ -1,0 +1,115 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/themes/app_theme.dart';
+import '../../providers/store_favorites_provider.dart';
+import 'store_detail_page.dart';
+
+class StoreSearchPage extends ConsumerStatefulWidget {
+  const StoreSearchPage({super.key});
+
+  @override
+  ConsumerState<StoreSearchPage> createState() => _StoreSearchPageState();
+}
+
+class _StoreSearchPageState extends ConsumerState<StoreSearchPage> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final favorites = ref.watch(storeFavoritesProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Buscar Estabelecimentos'),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(AppTheme.paddingMedium),
+            child: TextField(
+              controller: _controller,
+              decoration: InputDecoration(
+                hintText: 'Buscar estabelecimentos...',
+                prefixIcon: const Icon(Icons.search),
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.clear),
+                  onPressed: () => _controller.clear(),
+                ),
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+          ),
+          Expanded(
+            child: StreamBuilder<QuerySnapshot>(
+              stream: _buildQuery().snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final docs = snapshot.data?.docs ?? [];
+                if (docs.isEmpty) {
+                  return const Center(child: Text('Nenhum estabelecimento encontrado'));
+                }
+                final sortedDocs = docs.toList()
+                  ..sort((a, b) {
+                    final aFav = favorites.contains(a.id) ? 0 : 1;
+                    final bFav = favorites.contains(b.id) ? 0 : 1;
+                    return aFav.compareTo(bFav);
+                  });
+                return ListView.builder(
+                  itemCount: sortedDocs.length,
+                  padding: const EdgeInsets.all(AppTheme.paddingMedium),
+                  itemBuilder: (context, index) {
+                    final doc = sortedDocs[index];
+                    final data = doc.data() as Map<String, dynamic>;
+                    final isFav = favorites.contains(doc.id);
+                    return Card(
+                      child: ListTile(
+                        title: Text(data['name'] ?? 'Loja'),
+                        subtitle: Text(data['address'] ?? ''),
+                        trailing: IconButton(
+                          icon: Icon(
+                            isFav ? Icons.star : Icons.star_border,
+                            color: isFav ? Colors.amber : AppTheme.textSecondaryColor,
+                          ),
+                          onPressed: () {
+                            ref.read(storeFavoritesProvider.notifier).toggleFavorite(doc.id);
+                          },
+                        ),
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => StoreDetailPage(store: doc),
+                            ),
+                          );
+                        },
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Query _buildQuery() {
+    final text = _controller.text.trim();
+    var query = FirebaseFirestore.instance.collection('stores').orderBy('name');
+    if (text.isNotEmpty) {
+      query = query.startAt([text]).endAt(["$text\uf8ff"]);
+    }
+    return query;
+  }
+}

--- a/lib/presentation/providers/store_favorites_provider.dart
+++ b/lib/presentation/providers/store_favorites_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class StoreFavoritesNotifier extends StateNotifier<Set<String>> {
+  StoreFavoritesNotifier() : super(<String>{});
+
+  void toggleFavorite(String storeId) {
+    if (state.contains(storeId)) {
+      state = {...state}..remove(storeId);
+    } else {
+      state = {...state, storeId};
+    }
+  }
+
+  bool isFavorite(String storeId) => state.contains(storeId);
+}
+
+final storeFavoritesProvider =
+    StateNotifierProvider<StoreFavoritesNotifier, Set<String>>(
+        (ref) => StoreFavoritesNotifier());


### PR DESCRIPTION
## Summary
- implement store favorites provider
- add page to search establishments with favorites prioritized
- add store detail page showing related prices
- link store search from the main search page

## Testing
- `flutter format lib/presentation/providers/store_favorites_provider.dart lib/presentation/pages/store/store_search_page.dart lib/presentation/pages/store/store_detail_page.dart lib/presentation/pages/search/search_page.dart` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a35ed37c832f99826431b257e7fa