### PR TITLE
Implement price photo capture with location

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ O aplicativo segue uma identidade visual inspirada em economia colaborativa e si
 - Comparação de preços entre estabelecimentos
 
 ### 📝 Cadastro de Preços
-- Captura de foto do preço
+- Captura de foto do preço *(apenas pelo aplicativo para registrar a localização do usuário)*
+- Localização utilizada para sugerir ou cadastrar o estabelecimento
+- Se houver apenas um estabelecimento próximo, ele é sugerido automaticamente
 - Inserção manual de dados
 - Escaneamento de nota fiscal (OCR)
 - Validação por moderação

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   mask_text_input_formatter: ^2.5.0
 
   # Apenas para mobile (removidas para web)
-  # geolocator: ^10.1.0
+  geolocator: ^10.1.0
   # geocoding: ^2.1.1
   # camera: ^0.10.5+5
   image_picker: ^1.0.4


### PR DESCRIPTION
## Summary
- register geolocation when submitting price entry
- add mobile-only camera workflow with location capture
- document that photos must be taken in-app
- suggest nearby store when only one is found

## Testing
- `flutter format lib/presentation/pages/price/add_price_page.dart lib/presentation/pages/home/home_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852aeaf2c0c832f998b0bcb6a133b16