### PR TITLE
Fix store and product selection issue

### DIFF
--- a/lib/presentation/pages/product/product_search_page.dart
+++ b/lib/presentation/pages/product/product_search_page.dart
@@ -67,7 +67,6 @@ class _ProductSearchPageState extends State<ProductSearchPage> {
                         onTap: () {
                           if (widget.onSelected != null) {
                             widget.onSelected!(doc);
-                            Navigator.pop(context);
                           }
                         },
                       ),

--- a/lib/presentation/pages/store/store_search_page.dart
+++ b/lib/presentation/pages/store/store_search_page.dart
@@ -91,7 +91,6 @@ class _StoreSearchPageState extends ConsumerState<StoreSearchPage> {
                         onTap: () {
                           if (widget.onSelected != null) {
                             widget.onSelected!(doc);
-                            Navigator.pop(context);
                           } else {
                             Navigator.push(
                               context,


### PR DESCRIPTION
## Summary
- prevent double Navigator.pop when selecting stores
- apply same fix for product selection

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d5f102d8832fa09cf77dfddc0e59