### PR TITLE
Add barcode field to admin product pages

### DIFF
--- a/lib/presentation/pages/admin/add_product_page.dart
+++ b/lib/presentation/pages/admin/add_product_page.dart
@@ -23,6 +23,7 @@ class _AddProductPageState extends State<AddProductPage> {
   final _nameController = TextEditingController();
   final _brandController = TextEditingController();
   final _weightController = TextEditingController();
+  final _barcodeController = TextEditingController();
   final _descriptionController = TextEditingController();
   final ImagePicker _picker = ImagePicker();
   XFile? _imageFile;
@@ -33,6 +34,7 @@ class _AddProductPageState extends State<AddProductPage> {
     _nameController.dispose();
     _brandController.dispose();
     _weightController.dispose();
+    _barcodeController.dispose();
     _descriptionController.dispose();
     super.dispose();
   }
@@ -65,6 +67,7 @@ class _AddProductPageState extends State<AddProductPage> {
           'name': _nameController.text.trim(),
           'brand': _brandController.text.trim(),
           'weight': double.tryParse(_weightController.text.trim()),
+          'barcode': _barcodeController.text.trim(),
           'description': _descriptionController.text.trim(),
           'category': _category?.value,
           'image_url': imageUrl,
@@ -133,6 +136,16 @@ class _AddProductPageState extends State<AddProductPage> {
                 keyboardType:
                     const TextInputType.numberWithOptions(decimal: true),
                 validator: Validators.validateWeight,
+              ),
+              const SizedBox(height: AppTheme.paddingMedium),
+              TextFormField(
+                controller: _barcodeController,
+                decoration: const InputDecoration(
+                  labelText: 'Código de Barras',
+                  prefixIcon: Icon(Icons.qr_code),
+                ),
+                keyboardType: TextInputType.number,
+                validator: Validators.validateBarcode,
               ),
               const SizedBox(height: AppTheme.paddingMedium),
               DropdownButtonFormField<ProductCategory>(

--- a/lib/presentation/pages/admin/edit_product_page.dart
+++ b/lib/presentation/pages/admin/edit_product_page.dart
@@ -24,6 +24,7 @@ class _EditProductPageState extends State<EditProductPage> {
   late final TextEditingController _nameController;
   late final TextEditingController _brandController;
   late final TextEditingController _weightController;
+  late final TextEditingController _barcodeController;
   late final TextEditingController _descriptionController;
   final ImagePicker _picker = ImagePicker();
   XFile? _imageFile;
@@ -38,6 +39,7 @@ class _EditProductPageState extends State<EditProductPage> {
     _brandController = TextEditingController(text: data['brand'] ?? '');
     _weightController =
         TextEditingController(text: data['weight']?.toString() ?? '');
+    _barcodeController = TextEditingController(text: data['barcode'] ?? '');
     _descriptionController =
         TextEditingController(text: data['description'] ?? '');
     _category = ProductCategory.values.firstWhere(
@@ -52,6 +54,7 @@ class _EditProductPageState extends State<EditProductPage> {
     _nameController.dispose();
     _brandController.dispose();
     _weightController.dispose();
+    _barcodeController.dispose();
     _descriptionController.dispose();
     super.dispose();
   }
@@ -82,6 +85,7 @@ class _EditProductPageState extends State<EditProductPage> {
           'name': _nameController.text.trim(),
           'brand': _brandController.text.trim(),
           'weight': double.tryParse(_weightController.text.trim()),
+          'barcode': _barcodeController.text.trim(),
           'description': _descriptionController.text.trim(),
           'category': _category?.value,
           'image_url': imageUrl,
@@ -150,6 +154,16 @@ class _EditProductPageState extends State<EditProductPage> {
                 keyboardType:
                     const TextInputType.numberWithOptions(decimal: true),
                 validator: Validators.validateWeight,
+              ),
+              const SizedBox(height: AppTheme.paddingMedium),
+              TextFormField(
+                controller: _barcodeController,
+                decoration: const InputDecoration(
+                  labelText: 'Código de Barras',
+                  prefixIcon: Icon(Icons.qr_code),
+                ),
+                keyboardType: TextInputType.number,
+                validator: Validators.validateBarcode,
               ),
               const SizedBox(height: AppTheme.paddingMedium),
               DropdownButtonFormField<ProductCategory>(

--- a/lib/presentation/pages/admin/manage_products_page.dart
+++ b/lib/presentation/pages/admin/manage_products_page.dart
@@ -68,11 +68,18 @@ class ManageProductsPage extends StatelessWidget {
               final doc = docs[index];
               final data = doc.data() as Map<String, dynamic>;
               return ListTile(
-                leading:
-                    const Icon(Icons.shopping_bag, color: AppTheme.primaryColor),
+                leading: data['image_url'] != null &&
+                        (data['image_url'] as String).isNotEmpty
+                    ? CircleAvatar(
+                        backgroundImage: NetworkImage(data['image_url']),
+                      )
+                    : const Icon(Icons.shopping_bag,
+                        color: AppTheme.primaryColor),
                 title: Text(data['name'] ?? ''),
                 subtitle: Text(
-                    "${data['brand'] ?? ''} - ${data['weight'] ?? ''}kg"),
+                  "${data['brand'] ?? ''} - ${data['barcode'] ?? ''}\n${data['description'] ?? ''}",
+                ),
+                isThreeLine: true,
                 onTap: () {
                   Navigator.push(
                     context,


### PR DESCRIPTION
## Summary
- allow barcode entry when adding or editing products
- display product image, barcode and description in product list

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e6a4d280832fb18ddec656051fa7