### PR TITLE
Implement price search and details

### DIFF
--- a/lib/presentation/pages/map/map_page.dart
+++ b/lib/presentation/pages/map/map_page.dart
@@ -2,6 +2,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/themes/app_theme.dart';
+import '../price/price_search_page.dart';
+import '../price/price_detail_page.dart';
 
 class MapPage extends ConsumerStatefulWidget {
   const MapPage({super.key});
@@ -71,41 +73,52 @@ class _MapPageState extends ConsumerState<MapPage> {
             top: AppTheme.paddingMedium,
             left: AppTheme.paddingMedium,
             right: AppTheme.paddingMedium,
-            child: Card(
-              elevation: 4,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(AppTheme.radiusLarge),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppTheme.paddingMedium,
-                  vertical: AppTheme.paddingSmall,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(AppTheme.radiusLarge),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const PriceSearchPage(),
+                  ),
+                );
+              },
+              child: Card(
+                elevation: 4,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(AppTheme.radiusLarge),
                 ),
-                child: Row(
-                  children: [
-                    const Icon(
-                      Icons.search,
-                      color: AppTheme.textSecondaryColor,
-                    ),
-                    const SizedBox(width: AppTheme.paddingSmall),
-                    const Expanded(
-                      child: Text(
-                        'Buscar produtos...',
-                        style: TextStyle(
-                          color: AppTheme.textSecondaryColor,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppTheme.paddingMedium,
+                    vertical: AppTheme.paddingSmall,
+                  ),
+                  child: Row(
+                    children: [
+                      const Icon(
+                        Icons.search,
+                        color: AppTheme.textSecondaryColor,
+                      ),
+                      const SizedBox(width: AppTheme.paddingSmall),
+                      const Expanded(
+                        child: Text(
+                          'Buscar produtos...',
+                          style: TextStyle(
+                            color: AppTheme.textSecondaryColor,
+                          ),
                         ),
                       ),
-                    ),
-                    IconButton(
-                      icon: const Icon(
-                        Icons.tune,
-                        color: AppTheme.primaryColor,
+                      IconButton(
+                        icon: const Icon(
+                          Icons.tune,
+                          color: AppTheme.primaryColor,
+                        ),
+                        onPressed: () {
+                          _showFilterDialog(context);
+                        },
                       ),
-                      onPressed: () {
-                        _showFilterDialog(context);
-                      },
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -194,8 +207,7 @@ class _MapPageState extends ConsumerState<MapPage> {
                             itemCount: docs.length,
                             itemBuilder: (context, index) {
                               final doc = docs[index];
-                              final data = doc.data() as Map<String, dynamic>;
-                              return _buildPriceCard(data);
+                              return _buildPriceCard(doc);
                             },
                           );
                         },
@@ -211,7 +223,8 @@ class _MapPageState extends ConsumerState<MapPage> {
     );
   }
 
-  Widget _buildPriceCard(Map<String, dynamic> data) {
+  Widget _buildPriceCard(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
     final value = (data['price'] as num?)?.toDouble() ?? 0.0;
     final product = data['product_name'] ?? 'Produto';
     final store = data['store_name'] ?? 'Loja';
@@ -252,7 +265,12 @@ class _MapPageState extends ConsumerState<MapPage> {
           ],
         ),
         onTap: () {
-          // TODO: Ver detalhes do preço
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => PriceDetailPage(price: doc),
+            ),
+          );
         },
       ),
     );

--- a/lib/presentation/pages/price/price_detail_page.dart
+++ b/lib/presentation/pages/price/price_detail_page.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../../../core/themes/app_theme.dart';
+
+class PriceDetailPage extends StatelessWidget {
+  final DocumentSnapshot price;
+
+  const PriceDetailPage({required this.price, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final data = price.data() as Map<String, dynamic>;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Detalhes do Preço'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(AppTheme.paddingLarge),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              data['product_name'] ?? 'Produto',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: AppTheme.paddingMedium),
+            Text(
+              'Estabelecimento: ${data['store_name'] ?? ''}',
+            ),
+            const SizedBox(height: AppTheme.paddingMedium),
+            Text(
+              'R\$ ${(data['price'] as num).toStringAsFixed(2)}',
+              style: AppTheme.priceTextStyle,
+            ),
+            const SizedBox(height: AppTheme.paddingLarge),
+            const Text('Mais detalhes ser\u00e3o implementados futuramente.'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/price/price_search_page.dart
+++ b/lib/presentation/pages/price/price_search_page.dart
@@ -1,0 +1,103 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../../../core/themes/app_theme.dart';
+import 'price_detail_page.dart';
+
+class PriceSearchPage extends StatefulWidget {
+  const PriceSearchPage({super.key});
+
+  @override
+  State<PriceSearchPage> createState() => _PriceSearchPageState();
+}
+
+class _PriceSearchPageState extends State<PriceSearchPage> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Buscar Preços'),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(AppTheme.paddingMedium),
+            child: TextField(
+              controller: _controller,
+              decoration: InputDecoration(
+                hintText: 'Buscar produto...',
+                prefixIcon: const Icon(Icons.search),
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.clear),
+                  onPressed: () => _controller.clear(),
+                ),
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+          ),
+          Expanded(
+            child: StreamBuilder<QuerySnapshot>(
+              stream: _buildQuery().snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final docs = snapshot.data?.docs ?? [];
+                if (docs.isEmpty) {
+                  return const Center(child: Text('Nenhum pre\u00e7o encontrado'));
+                }
+                return ListView.builder(
+                  itemCount: docs.length,
+                  padding: const EdgeInsets.all(AppTheme.paddingMedium),
+                  itemBuilder: (context, index) {
+                    final doc = docs[index];
+                    final data = doc.data() as Map<String, dynamic>;
+                    return Card(
+                      child: ListTile(
+                        title: Text(data['product_name'] ?? 'Produto'),
+                        subtitle: Text(data['store_name'] ?? 'Loja'),
+                        trailing: Text(
+                          'R\$ ${(data['price'] as num).toStringAsFixed(2)}',
+                          style: AppTheme.priceTextStyle,
+                        ),
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => PriceDetailPage(price: doc),
+                            ),
+                          );
+                        },
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Query _buildQuery() {
+    final text = _controller.text.trim();
+    if (text.isNotEmpty) {
+      return FirebaseFirestore.instance
+          .collection('prices')
+          .orderBy('product_name')
+          .startAt([text]).endAt(['$text\uf8ff']);
+    }
+    return FirebaseFirestore.instance
+        .collection('prices')
+        .orderBy('created_at', descending: true);
+  }
+}

--- a/lib/presentation/pages/store/store_detail_page.dart
+++ b/lib/presentation/pages/store/store_detail_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/store_favorites_provider.dart';
+import '../price/price_detail_page.dart';
 
 class StoreDetailPage extends ConsumerWidget {
   final DocumentSnapshot store;
@@ -59,16 +60,37 @@ class StoreDetailPage extends ConsumerWidget {
                 if (docs.isEmpty) {
                   return const Center(child: Text('Nenhum preço para este estabelecimento'));
                 }
+
+                final Map<String, DocumentSnapshot> latest = {};
+                for (final doc in docs) {
+                  final data = doc.data() as Map<String, dynamic>;
+                  final productId = data['product_id'] as String?;
+                  if (productId == null) continue;
+                  if (!latest.containsKey(productId)) {
+                    latest[productId] = doc;
+                  }
+                }
+                final prices = latest.values.toList();
+
                 return ListView.builder(
-                  itemCount: docs.length,
+                  itemCount: prices.length,
                   itemBuilder: (context, index) {
-                    final priceData = docs[index].data() as Map<String, dynamic>;
+                    final doc = prices[index];
+                    final priceData = doc.data() as Map<String, dynamic>;
                     return ListTile(
                       title: Text(priceData['product_name'] ?? ''),
                       trailing: Text(
                         'R\$ ${(priceData['price'] as num).toStringAsFixed(2)}',
                         style: AppTheme.priceTextStyle,
                       ),
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => PriceDetailPage(price: doc),
+                          ),
+                        );
+                      },
                     );
                   },
                 );


### PR DESCRIPTION
## Summary
- add price detail page
- add price search page and link from map
- show only latest price per product on store screen
- navigate to price detail from map and store

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f4fa387c832f881b37c37692b33b