### PR TITLE
Fix google_place dependency version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   # Networking
   dio: ^5.3.2
   http: 1.1.0
-  google_place: ^0.5.7
+  google_place: ^0.5.6
 
   # Autenticação Social
   google_sign_in: ^6.1.6


### PR DESCRIPTION
## Summary
- correct the google_place dependency version in `pubspec.yaml`

## Testing
- `flutter pub get` *(fails: flutter not installed)*
- `dart pub get` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685308009050832f867b0b11350bd7ec