### PR TITLE
Fix Google Places API property names

### DIFF
--- a/lib/presentation/pages/store/place_search_page.dart
+++ b/lib/presentation/pages/store/place_search_page.dart
@@ -73,15 +73,15 @@ class _PlaceSearchPageState extends State<PlaceSearchPage> {
               itemBuilder: (context, index) {
                 final p = _predictions[index];
                 return ListTile(
-                  title: Text(p.description ?? ''),
+                  title: Text(p.text ?? ''),
                   onTap: () async {
                     final detail = await _places.fetchPlace(
                       p.placeId!,
                       fields: [
-                        PlaceField.ID,
-                        PlaceField.ADDRESS,
-                        PlaceField.LAT_LNG,
-                        PlaceField.NAME,
+                        PlaceField.id,
+                        PlaceField.address,
+                        PlaceField.latLng,
+                        PlaceField.name,
                       ],
                     );
                     if (detail.place != null) {


### PR DESCRIPTION
## Summary
- update fields used in place search page to match the newer `flutter_google_places_sdk` API

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68530d4eea54832f8bc1157c64722e4d