### PR TITLE
Fix Google Places fields for version 0.2.7

### DIFF
--- a/lib/presentation/pages/store/place_search_page.dart
+++ b/lib/presentation/pages/store/place_search_page.dart
@@ -73,15 +73,15 @@ class _PlaceSearchPageState extends State<PlaceSearchPage> {
               itemBuilder: (context, index) {
                 final p = _predictions[index];
                 return ListTile(
-                  title: Text(p.text ?? ''),
+                  title: Text(p.description ?? ''),
                   onTap: () async {
                     final detail = await _places.fetchPlace(
                       p.placeId!,
                       fields: [
-                        PlaceField.id,
-                        PlaceField.address,
-                        PlaceField.latLng,
-                        PlaceField.name,
+                        PlaceField.ID,
+                        PlaceField.ADDRESS,
+                        PlaceField.LAT_LNG,
+                        PlaceField.NAME,
                       ],
                     );
                     if (detail.place != null) {


### PR DESCRIPTION
## Summary
- revert PlaceField names to use the constants expected by flutter_google_places_sdk 0.2.7
- use `description` from predictions instead of `text`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter test integration_test/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685311ed1dc0832f80eca5500ee42f74