### PR TITLE
Simplify Google Maps search

### DIFF
--- a/lib/data/datasources/places_service.dart
+++ b/lib/data/datasources/places_service.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../../core/constants/app_constants.dart';
+import '../models/place_result.dart';
+
+class PlacesService {
+  final http.Client _client;
+
+  PlacesService({http.Client? client}) : _client = client ?? http.Client();
+
+  Future<List<PlaceResult>> searchPlacesByName({
+    required String name,
+    double? latitude,
+    double? longitude,
+    int radiusInMeters = 5000,
+  }) async {
+    final queryParameters = {
+      'key': AppConstants.googleMapsApiKey,
+      'query': name,
+      'radius': '$radiusInMeters',
+      if (latitude != null && longitude != null)
+        'location': '$latitude,$longitude',
+    };
+
+    final uri = Uri.https(
+      'maps.googleapis.com',
+      '/maps/api/place/textsearch/json',
+      queryParameters,
+    );
+
+    final response = await _client.get(uri);
+    if (response.statusCode != 200) {
+      throw Exception('Erro ao buscar locais: ${response.statusCode}');
+    }
+
+    final data = json.decode(response.body) as Map<String, dynamic>;
+    final results = data['results'] as List<dynamic>?;
+    if (results == null) return [];
+    return results
+        .map((e) => PlaceResult.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/lib/data/models/place_result.dart
+++ b/lib/data/models/place_result.dart
@@ -1,0 +1,23 @@
+class PlaceResult {
+  final String id;
+  final String name;
+  final double latitude;
+  final double longitude;
+
+  const PlaceResult({
+    required this.id,
+    required this.name,
+    required this.latitude,
+    required this.longitude,
+  });
+
+  factory PlaceResult.fromJson(Map<String, dynamic> json) {
+    final location = json['geometry']['location'] as Map<String, dynamic>;
+    return PlaceResult(
+      id: json['place_id'] as String,
+      name: json['name'] as String,
+      latitude: (location['lat'] as num).toDouble(),
+      longitude: (location['lng'] as num).toDouble(),
+    );
+  }
+}

--- a/lib/presentation/pages/store/add_store_page.dart
+++ b/lib/presentation/pages/store/add_store_page.dart
@@ -4,7 +4,7 @@ import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/validators.dart';
 import '../../../core/logging/firebase_logger.dart';
 import 'place_search_page.dart';
-import 'package:flutter_google_places_sdk/flutter_google_places_sdk.dart';
+import '../../../data/models/place_result.dart';
 
 class AddStorePage extends StatefulWidget {
   const AddStorePage({super.key});
@@ -68,11 +68,11 @@ class _AddStorePageState extends State<AddStorePage> {
         builder: (_) => const PlaceSearchPage(),
       ),
     );
-    if (result is Place) {
+    if (result is PlaceResult) {
       setState(() {
-        _addressController.text = result.address ?? result.name ?? '';
-        _latitude = result.latLng?.lat;
-        _longitude = result.latLng?.lng;
+        _addressController.text = result.name;
+        _latitude = result.latitude;
+        _longitude = result.longitude;
         _placeId = result.id;
       });
     }


### PR DESCRIPTION
## Summary
- create a small model `PlaceResult`
- add `PlacesService` to query the Google Places API via HTTP
- update place search page to use the new service and show coordinates
- adjust add store page to handle the new place result

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685357e1f680832f8e04415a64baaaac