### PR TITLE
Show map in store detail and add price action

### DIFF
--- a/lib/presentation/pages/price/add_price_page.dart
+++ b/lib/presentation/pages/price/add_price_page.dart
@@ -9,7 +9,9 @@ import '../product/product_search_page.dart';
 import '../store/store_search_page.dart';
 
 class AddPricePage extends StatefulWidget {
-  const AddPricePage({super.key});
+  final DocumentSnapshot? store;
+
+  const AddPricePage({this.store, super.key});
 
   @override
   State<AddPricePage> createState() => _AddPricePageState();
@@ -27,6 +29,11 @@ class _AddPricePageState extends State<AddPricePage> {
   @override
   void initState() {
     super.initState();
+    if (widget.store != null) {
+      _selectedStore = widget.store;
+      final data = widget.store!.data() as Map<String, dynamic>;
+      _storeController.text = data['name'] ?? '';
+    }
     _loadNearbyStores();
   }
 

--- a/lib/presentation/pages/store/store_detail_page.dart
+++ b/lib/presentation/pages/store/store_detail_page.dart
@@ -3,9 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/themes/app_theme.dart';
+import '../../../core/constants/app_constants.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/store_favorites_provider.dart';
 import '../price/price_detail_page.dart';
+import '../price/add_price_page.dart';
 
 class StoreDetailPage extends ConsumerWidget {
   final DocumentSnapshot store;
@@ -40,6 +42,13 @@ class StoreDetailPage extends ConsumerWidget {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          if (data['latitude'] != null && data['longitude'] != null)
+            Image.network(
+              'https://maps.googleapis.com/maps/api/staticmap?center=${data['latitude']},${data['longitude']}&zoom=16&size=600x200&markers=color:red%7C${data['latitude']},${data['longitude']}&key=${AppConstants.googleMapsApiKey}',
+              width: double.infinity,
+              height: 200,
+              fit: BoxFit.cover,
+            ),
           Padding(
             padding: const EdgeInsets.all(AppTheme.paddingMedium),
             child: Text(data['address'] ?? ''),
@@ -98,6 +107,17 @@ class StoreDetailPage extends ConsumerWidget {
             ),
           ),
         ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => AddPricePage(store: store),
+            ),
+          );
+        },
+        child: const Icon(Icons.add),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- allow passing store to `AddPricePage`
- show a static Google Maps preview in `StoreDetailPage`
- add button to register a price from store details

## Testing
- `dart format lib/presentation/pages/price/add_price_page.dart lib/presentation/pages/store/store_detail_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536e476410832fa4c09108097a4a9c