### PR TITLE
Add price update option

### DIFF
--- a/lib/presentation/pages/price/price_detail_page.dart
+++ b/lib/presentation/pages/price/price_detail_page.dart
@@ -2,11 +2,37 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
 import '../../../core/themes/app_theme.dart';
+import 'add_price_page.dart';
 
 class PriceDetailPage extends StatelessWidget {
   final DocumentSnapshot price;
 
   const PriceDetailPage({required this.price, super.key});
+
+  Future<void> _updatePrice(BuildContext context) async {
+    final data = price.data() as Map<String, dynamic>;
+    final productId = data['product_id'] as String?;
+    final storeId = data['store_id'] as String?;
+    if (productId == null || storeId == null) return;
+
+    final productDoc = await FirebaseFirestore.instance
+        .collection('products')
+        .doc(productId)
+        .get();
+    final storeDoc = await FirebaseFirestore.instance
+        .collection('stores')
+        .doc(storeId)
+        .get();
+
+    if (!context.mounted) return;
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => AddPricePage(product: productDoc, store: storeDoc),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -37,6 +63,10 @@ class PriceDetailPage extends StatelessWidget {
             const Text('Mais detalhes ser\u00e3o implementados futuramente.'),
           ],
         ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _updatePrice(context),
+        child: const Icon(Icons.edit),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- enable updating a price from the detail page

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter test integration_test/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685371f92d04832fa302f5410c4b6bf9