### PR TITLE
Add map image capture when registering a store

### DIFF
--- a/lib/presentation/pages/store/store_detail_page.dart
+++ b/lib/presentation/pages/store/store_detail_page.dart
@@ -42,7 +42,15 @@ class StoreDetailPage extends ConsumerWidget {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (data['latitude'] != null && data['longitude'] != null)
+          if (data['map_image_url'] != null &&
+              (data['map_image_url'] as String).isNotEmpty)
+            Image.network(
+              data['map_image_url'],
+              width: double.infinity,
+              height: 200,
+              fit: BoxFit.cover,
+            )
+          else if (data['latitude'] != null && data['longitude'] != null)
             Image.network(
               'https://maps.googleapis.com/maps/api/staticmap?center=${data['latitude']},${data['longitude']}&zoom=16&size=600x200&markers=color:red%7C${data['latitude']},${data['longitude']}&key=${AppConstants.googleMapsApiKey}',
               width: double.infinity,


### PR DESCRIPTION
## Summary
- capture a static map image when creating a store
- upload the image to Firebase Storage and save URL
- display saved map image in store detail if available

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685372cc5378832fa6b09538204da72e