### PR TITLE
Update price input UX

### DIFF
--- a/lib/core/utils/price_input_formatter.dart
+++ b/lib/core/utils/price_input_formatter.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/services.dart';
+
+import 'formatters.dart';
+
+/// [TextInputFormatter] that formats the input as a monetary value using
+/// Brazilian conventions. Only digits are accepted and a comma is
+/// automatically inserted for the two decimal places.
+class PriceInputFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final digits = newValue.text.replaceAll(RegExp(r'[^0-9]'), '');
+
+    if (digits.isEmpty) {
+      return const TextEditingValue(
+        text: '',
+        selection: TextSelection.collapsed(offset: 0),
+      );
+    }
+
+    final value = double.parse(digits) / 100;
+    final newText = Formatters.formatPriceValue(value);
+
+    return TextEditingValue(
+      text: newText,
+      selection: TextSelection.collapsed(offset: newText.length),
+    );
+  }
+}

--- a/lib/presentation/pages/price/add_price_page.dart
+++ b/lib/presentation/pages/price/add_price_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
+import '../../../core/utils/price_input_formatter.dart';
 import '../../../core/utils/validators.dart';
 import '../../../core/logging/firebase_logger.dart';
 import '../product/product_search_page.dart';
@@ -259,9 +260,10 @@ class _AddPricePageState extends State<AddPricePage> {
               TextFormField(
                 controller: _priceController,
                 keyboardType: TextInputType.number,
+                inputFormatters: [PriceInputFormatter()],
                 decoration: const InputDecoration(
                   labelText: 'Preço',
-                  prefixIcon: Icon(Icons.attach_money),
+                  prefixText: 'R\$ ',
                 ),
                 validator: Validators.validatePrice,
               ),


### PR DESCRIPTION
## Summary
- include a new `PriceInputFormatter` for digit-only currency input
- use the formatter on the Add Price screen with `R$` prefix

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685373c4abd0832fb01fd461d3af77e9