### PR TITLE
Add dedicated prices page for stores

### DIFF
--- a/lib/presentation/pages/store/store_detail_page.dart
+++ b/lib/presentation/pages/store/store_detail_page.dart
@@ -6,8 +6,7 @@ import '../../../core/themes/app_theme.dart';
 import '../../../core/constants/app_constants.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/store_favorites_provider.dart';
-import '../price/price_detail_page.dart';
-import '../price/add_price_page.dart';
+// Página de detalhes exibe apenas informações do estabelecimento.
 
 class StoreDetailPage extends ConsumerWidget {
   final DocumentSnapshot store;
@@ -61,72 +60,17 @@ class StoreDetailPage extends ConsumerWidget {
             padding: const EdgeInsets.all(AppTheme.paddingMedium),
             child: Text(data['address'] ?? ''),
           ),
-          const Divider(),
-          Expanded(
-            child: StreamBuilder<QuerySnapshot>(
-              stream: FirebaseFirestore.instance
-                  .collection('prices')
-                  .where('store_id', isEqualTo: store.id)
-                  .orderBy('created_at', descending: true)
-                  .snapshots(),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const Center(child: CircularProgressIndicator());
-                }
-                final docs = snapshot.data?.docs ?? [];
-                if (docs.isEmpty) {
-                  return const Center(child: Text('Nenhum preço para este estabelecimento'));
-                }
-
-                final Map<String, DocumentSnapshot> latest = {};
-                for (final doc in docs) {
-                  final data = doc.data() as Map<String, dynamic>;
-                  final productId = data['product_id'] as String?;
-                  if (productId == null) continue;
-                  if (!latest.containsKey(productId)) {
-                    latest[productId] = doc;
-                  }
-                }
-                final prices = latest.values.toList();
-
-                return ListView.builder(
-                  itemCount: prices.length,
-                  itemBuilder: (context, index) {
-                    final doc = prices[index];
-                    final priceData = doc.data() as Map<String, dynamic>;
-                    return ListTile(
-                      title: Text(priceData['product_name'] ?? ''),
-                      trailing: Text(
-                        'R\$ ${(priceData['price'] as num).toStringAsFixed(2)}',
-                        style: AppTheme.priceTextStyle,
-                      ),
-                      onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (_) => PriceDetailPage(price: doc),
-                          ),
-                        );
-                      },
-                    );
-                  },
-                );
-              },
+          const SizedBox(height: AppTheme.paddingLarge),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppTheme.paddingMedium),
+            child: Text(
+              'Mais informações serão disponibilizadas em futuras versões.',
+              style: Theme.of(context).textTheme.bodyMedium,
             ),
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => AddPricePage(store: store),
-            ),
-          );
-        },
-        child: const Icon(Icons.add),
-      ),
+      // Sem ações nesta tela
     );
   }
 

--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -1,0 +1,145 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/themes/app_theme.dart';
+import '../../providers/auth_provider.dart';
+import '../../providers/store_favorites_provider.dart';
+import '../price/add_price_page.dart';
+import '../price/price_detail_page.dart';
+import 'store_detail_page.dart';
+
+class StorePricesPage extends ConsumerWidget {
+  final DocumentSnapshot store;
+  const StorePricesPage({required this.store, super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final data = store.data() as Map<String, dynamic>;
+    final isFav = ref.watch(storeFavoritesProvider).contains(store.id);
+    final isAdmin = ref.watch(isAdminProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(data['name'] ?? 'Estabelecimento'),
+        actions: [
+          IconButton(
+            icon: Icon(
+              isFav ? Icons.star : Icons.star_border,
+              color: isFav ? Colors.amber : AppTheme.textOnPrimaryColor,
+            ),
+            onPressed: () {
+              ref.read(storeFavoritesProvider.notifier).toggleFavorite(store.id);
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.info_outline),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => StoreDetailPage(store: store),
+                ),
+              );
+            },
+          ),
+          if (isAdmin)
+            IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: () => _deleteStore(context),
+            ),
+        ],
+      ),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('prices')
+            .where('store_id', isEqualTo: store.id)
+            .orderBy('created_at', descending: true)
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('Nenhum preço para este estabelecimento'));
+          }
+
+          final Map<String, DocumentSnapshot> latest = {};
+          for (final doc in docs) {
+            final priceData = doc.data() as Map<String, dynamic>;
+            final productId = priceData['product_id'] as String?;
+            if (productId == null) continue;
+            if (!latest.containsKey(productId)) {
+              latest[productId] = doc;
+            }
+          }
+          final prices = latest.values.toList();
+
+          return ListView.builder(
+            itemCount: prices.length,
+            itemBuilder: (context, index) {
+              final doc = prices[index];
+              final priceData = doc.data() as Map<String, dynamic>;
+              return ListTile(
+                title: Text(priceData['product_name'] ?? ''),
+                trailing: Text(
+                  'R\$ ${(priceData['price'] as num).toStringAsFixed(2)}',
+                  style: AppTheme.priceTextStyle,
+                ),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => PriceDetailPage(price: doc),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => AddPricePage(store: store),
+            ),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Future<void> _deleteStore(BuildContext context) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Excluir Estabelecimento'),
+        content: const Text('Tem certeza que deseja excluir este estabelecimento?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Excluir'),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      await store.reference.delete();
+      if (context.mounted) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Estabelecimento excluído')),
+        );
+      }
+    }
+  }
+}

--- a/lib/presentation/pages/store/store_search_page.dart
+++ b/lib/presentation/pages/store/store_search_page.dart
@@ -6,7 +6,7 @@ import '../../../core/themes/app_theme.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/store_favorites_provider.dart';
 import 'add_store_page.dart';
-import 'store_detail_page.dart';
+import 'store_prices_page.dart';
 
 class StoreSearchPage extends ConsumerStatefulWidget {
   final ValueChanged<DocumentSnapshot>? onSelected;
@@ -95,7 +95,7 @@ class _StoreSearchPageState extends ConsumerState<StoreSearchPage> {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
-                                builder: (_) => StoreDetailPage(store: doc),
+                                builder: (_) => StorePricesPage(store: doc),
                               ),
                             );
                           }


### PR DESCRIPTION
## Summary
- create `StorePricesPage` to list prices for a store
- remove price list from `StoreDetailPage`
- open `StorePricesPage` from `StoreSearchPage`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685374b6ccb4832fa1dbda05503e53d2