### PR TITLE
Implement product price list flow

### DIFF
--- a/lib/presentation/pages/product/product_detail_page.dart
+++ b/lib/presentation/pages/product/product_detail_page.dart
@@ -2,8 +2,6 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
 import '../../../core/themes/app_theme.dart';
-import '../price/add_price_page.dart';
-import '../price/price_detail_page.dart';
 
 class ProductDetailPage extends StatelessWidget {
   final DocumentSnapshot product;
@@ -16,8 +14,7 @@ class ProductDetailPage extends StatelessWidget {
       appBar: AppBar(
         title: Text(data['name'] ?? 'Produto'),
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      body: ListView(
         children: [
           if (data['image_url'] != null && (data['image_url'] as String).isNotEmpty)
             Image.network(
@@ -28,71 +25,29 @@ class ProductDetailPage extends StatelessWidget {
             ),
           Padding(
             padding: const EdgeInsets.all(AppTheme.paddingMedium),
-            child: Text(data['brand'] ?? ''),
-          ),
-          const Divider(),
-          Expanded(
-            child: StreamBuilder<QuerySnapshot>(
-              stream: FirebaseFirestore.instance
-                  .collection('prices')
-                  .where('product_id', isEqualTo: product.id)
-                  .orderBy('created_at', descending: true)
-                  .snapshots(),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const Center(child: CircularProgressIndicator());
-                }
-                final docs = snapshot.data?.docs ?? [];
-                if (docs.isEmpty) {
-                  return const Center(child: Text('Nenhum preço para este produto'));
-                }
-                final Map<String, DocumentSnapshot> latest = {};
-                for (final doc in docs) {
-                  final data = doc.data() as Map<String, dynamic>;
-                  final storeId = data['store_id'] as String?;
-                  if (storeId == null) continue;
-                  if (!latest.containsKey(storeId)) {
-                    latest[storeId] = doc;
-                  }
-                }
-                final prices = latest.values.toList();
-                return ListView.builder(
-                  itemCount: prices.length,
-                  itemBuilder: (context, index) {
-                    final doc = prices[index];
-                    final priceData = doc.data() as Map<String, dynamic>;
-                    return ListTile(
-                      title: Text(priceData['store_name'] ?? ''),
-                      trailing: Text(
-                        'R\$ ${(priceData['price'] as num).toStringAsFixed(2)}',
-                        style: AppTheme.priceTextStyle,
-                      ),
-                      onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (_) => PriceDetailPage(price: doc),
-                          ),
-                        );
-                      },
-                    );
-                  },
-                );
-              },
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  data['brand'] ?? '',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                if (data['weight'] != null) ...[
+                  const SizedBox(height: AppTheme.paddingSmall),
+                  Text('Peso: ${data['weight']} kg'),
+                ],
+                if (data['barcode'] != null && (data['barcode'] as String).isNotEmpty) ...[
+                  const SizedBox(height: AppTheme.paddingSmall),
+                  Text('Código de barras: ${data['barcode']}'),
+                ],
+                if (data['description'] != null && (data['description'] as String).isNotEmpty) ...[
+                  const SizedBox(height: AppTheme.paddingMedium),
+                  Text(data['description']),
+                ],
+              ],
             ),
           ),
         ],
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => AddPricePage(product: product),
-            ),
-          );
-        },
-        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/presentation/pages/product/product_prices_page.dart
+++ b/lib/presentation/pages/product/product_prices_page.dart
@@ -1,0 +1,117 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/themes/app_theme.dart';
+import '../../providers/store_favorites_provider.dart';
+import '../price/add_price_page.dart';
+import '../price/price_detail_page.dart';
+import 'product_detail_page.dart';
+
+class ProductPricesPage extends ConsumerWidget {
+  final DocumentSnapshot product;
+  const ProductPricesPage({required this.product, super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final favorites = ref.watch(storeFavoritesProvider);
+    final data = product.data() as Map<String, dynamic>;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(data['name'] ?? 'Produto'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.info_outline),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => ProductDetailPage(product: product),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('prices')
+            .where('product_id', isEqualTo: product.id)
+            .orderBy('created_at', descending: true)
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('Nenhum pre\u00e7o para este produto'));
+          }
+          final Map<String, DocumentSnapshot> latest = {};
+          for (final doc in docs) {
+            final priceData = doc.data() as Map<String, dynamic>;
+            final storeId = priceData['store_id'] as String?;
+            if (storeId == null) continue;
+            if (!latest.containsKey(storeId)) {
+              latest[storeId] = doc;
+            }
+          }
+          final prices = latest.values.toList()
+            ..sort((a, b) {
+              final aFav = favorites.contains((a.data() as Map<String, dynamic>)['store_id']) ? 0 : 1;
+              final bFav = favorites.contains((b.data() as Map<String, dynamic>)['store_id']) ? 0 : 1;
+              return aFav.compareTo(bFav);
+            });
+
+          return ListView.builder(
+            itemCount: prices.length,
+            itemBuilder: (context, index) {
+              final doc = prices[index];
+              final priceData = doc.data() as Map<String, dynamic>;
+              final storeId = priceData['store_id'] as String?;
+              final isFav = storeId != null && favorites.contains(storeId);
+              return ListTile(
+                leading: IconButton(
+                  icon: Icon(
+                    isFav ? Icons.star : Icons.star_border,
+                    color: isFav ? Colors.amber : AppTheme.textSecondaryColor,
+                  ),
+                  onPressed: storeId == null
+                      ? null
+                      : () {
+                          ref.read(storeFavoritesProvider.notifier).toggleFavorite(storeId);
+                        },
+                ),
+                title: Text(priceData['store_name'] ?? ''),
+                trailing: Text(
+                  'R\$ ${(priceData['price'] as num).toStringAsFixed(2)}',
+                  style: AppTheme.priceTextStyle,
+                ),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => PriceDetailPage(price: doc),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => AddPricePage(product: product),
+            ),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/product/product_search_page.dart
+++ b/lib/presentation/pages/product/product_search_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/themes/app_theme.dart';
 import '../admin/add_product_page.dart';
-import '../product/product_detail_page.dart';
+import '../product/product_prices_page.dart';
 import '../../providers/auth_provider.dart';
 class ProductSearchPage extends ConsumerStatefulWidget {
   final ValueChanged<DocumentSnapshot>? onSelected;
@@ -74,7 +74,7 @@ class _ProductSearchPageState extends ConsumerState<ProductSearchPage> {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
-                                builder: (_) => ProductDetailPage(product: doc),
+                                builder: (_) => ProductPricesPage(product: doc),
                               ),
                             );
                           }


### PR DESCRIPTION
## Summary
- add a new `ProductPricesPage`
- show product details on a dedicated page
- update product search to open the list of prices first

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685375cd8e2c832f9ca99b77afe65e34