### PR TITLE
Add redundant info in price records

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,16 +247,20 @@ class Price {
   final String userId;
   final double value;
   final String? imageUrl;
+  final String? productDescription;
+  final String? storeDescription;
+  final double? latitude;
+  final double? longitude;
   final DateTime createdAt;
   final DateTime? expiresAt;
   final bool isApproved;
 }
 ```
 
-Os preços não possuem mais latitude e longitude próprios. Eles são sempre
-vinculados a um `Store`, que contém as coordenadas. Caso o estabelecimento seja
-desconhecido, basta criar um `Store` anônimo com a localização informada e
-associar o preço a esse novo registro.
+Os preços voltam a armazenar suas próprias coordenadas geográficas, além de
+manter as descrições do produto e do estabelecimento no registro. Essa
+redundância permite consultas mais rápidas mesmo que as informações de produto
+ou loja sejam alteradas posteriormente.
 
 ## 🎯 Funcionalidades Implementadas
 

--- a/lib/domain/entities/price.dart
+++ b/lib/domain/entities/price.dart
@@ -8,6 +8,10 @@ class Price extends Equatable {
   final String userId;
   final double value;
   final String? imageUrl;
+  final String? productDescription;
+  final String? storeDescription;
+  final double? latitude;
+  final double? longitude;
   final DateTime createdAt;
   final DateTime? expiresAt;
   final bool isApproved;
@@ -25,6 +29,10 @@ class Price extends Equatable {
     required this.userId,
     required this.value,
     this.imageUrl,
+    this.productDescription,
+    this.storeDescription,
+    this.latitude,
+    this.longitude,
     required this.createdAt,
     this.expiresAt,
     required this.isApproved,
@@ -43,6 +51,10 @@ class Price extends Equatable {
     String? userId,
     double? value,
     String? imageUrl,
+    String? productDescription,
+    String? storeDescription,
+    double? latitude,
+    double? longitude,
     DateTime? createdAt,
     DateTime? expiresAt,
     bool? isApproved,
@@ -60,6 +72,10 @@ class Price extends Equatable {
       userId: userId ?? this.userId,
       value: value ?? this.value,
       imageUrl: imageUrl ?? this.imageUrl,
+      productDescription: productDescription ?? this.productDescription,
+      storeDescription: storeDescription ?? this.storeDescription,
+      latitude: latitude ?? this.latitude,
+      longitude: longitude ?? this.longitude,
       createdAt: createdAt ?? this.createdAt,
       expiresAt: expiresAt ?? this.expiresAt,
       isApproved: isApproved ?? this.isApproved,
@@ -96,6 +112,10 @@ class Price extends Equatable {
         userId,
         value,
         imageUrl,
+        productDescription,
+        storeDescription,
+        latitude,
+        longitude,
         createdAt,
         expiresAt,
         isApproved,

--- a/lib/presentation/pages/price/add_price_page.dart
+++ b/lib/presentation/pages/price/add_price_page.dart
@@ -147,11 +147,31 @@ class _AddPricePageState extends State<AddPricePage> {
       final priceValue = Formatters.parsePrice(_priceController.text.trim());
 
       try {
+        Position? position;
+        try {
+          final permission = await Geolocator.requestPermission();
+          if (permission != LocationPermission.denied &&
+              permission != LocationPermission.deniedForever) {
+            position = await Geolocator.getCurrentPosition();
+          }
+        } catch (e) {
+          FirebaseLogger.log('Location error', {'error': e.toString()});
+        }
+
+        final productData = _selectedProduct!.data() as Map<String, dynamic>;
+        final storeData = _selectedStore!.data() as Map<String, dynamic>;
+
         final data = {
           'product_id': _selectedProduct!.id,
+          'product_description': productData['description'],
           'store_id': _selectedStore!.id,
+          'store_description': storeData['description'],
           'price': priceValue,
           'created_at': Timestamp.now(),
+          if (position != null) ...{
+            'latitude': position.latitude,
+            'longitude': position.longitude,
+          },
         };
         FirebaseLogger.log('Adding price', data);
         await FirebaseFirestore.instance.collection('prices').add(data);


### PR DESCRIPTION
## Summary
- reintroduce redundant fields to price entity and submission form
- log product/store descriptions and coordinates when adding prices
- document new price fields in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685380889f10832f9e62f98e17034034