### PR TITLE
Fix new prices visibility

### DIFF
--- a/lib/presentation/pages/price/add_price_page.dart
+++ b/lib/presentation/pages/price/add_price_page.dart
@@ -168,6 +168,7 @@ class _AddPricePageState extends State<AddPricePage> {
           'store_description': storeData['description'],
           'price': priceValue,
           'created_at': Timestamp.now(),
+          'isApproved': true,
           if (position != null) ...{
             'latitude': position.latitude,
             'longitude': position.longitude,


### PR DESCRIPTION
## Summary
- include the `isApproved` flag when adding a price so recent entries can be read

## Testing
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685383fd05b8832fa0699dbd63d6d91d