### PR TITLE
Rename 'Estabelecimento' references to 'Comércio'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,25 +24,25 @@ O aplicativo segue uma identidade visual inspirada em economia colaborativa e si
 ### 🗺️ Mapa de Preços
 - Visualização de preços em mapa interativo
 - Busca por raio geográfico
-- Filtros por categoria e estabelecimento
+- Filtros por categoria e comércio
 - Localização automática do usuário
 
 ### 🔍 Busca de Produtos
 - Busca por nome do produto
 - Filtros por categoria
 - Ordenação por preço e distância
-- Comparação de preços entre estabelecimentos
+- Comparação de preços entre comércios
 
 ### 📝 Cadastro de Preços
 - Captura de foto do preço *(apenas pelo aplicativo para registrar a localização do usuário)*
-- Localização utilizada para sugerir ou cadastrar o estabelecimento
+- Localização utilizada para sugerir ou cadastrar o comércio
 - Inserção manual de dados
 - Escaneamento de nota fiscal (OCR)
 - Validação por moderação
 
 ### 🛒 Listas de Compras
 - Criação de múltiplas listas
-- Cálculo de valor total por estabelecimento
+- Cálculo de valor total por comércio
 - Sugestão de melhor combinação de lojas
 - Acompanhamento de progresso
 
@@ -219,7 +219,7 @@ class Product {
 }
 ```
 
-### Store (Estabelecimento)
+### Store (Comércio)
 ```dart
 class Store {
   final String id;
@@ -233,9 +233,9 @@ class Store {
 }
 ```
 
-Para registrar preços quando o nome do estabelecimento for desconhecido,
+Para registrar preços quando o nome do comércio for desconhecido,
 crie um novo `Store` anônimo contendo as coordenadas do local. É possível
-cadastrar quantos estabelecimentos anônimos forem necessários, cada um com um
+cadastrar quantos comércios anônimos forem necessários, cada um com um
 `id` distinto e sua respectiva localização.
 
 ### Price (Preço)
@@ -258,7 +258,7 @@ class Price {
 ```
 
 Os preços voltam a armazenar suas próprias coordenadas geográficas, além de
-manter as descrições do produto e do estabelecimento no registro. Essa
+manter as descrições do produto e do comércio no registro. Essa
 redundância permite consultas mais rápidas mesmo que as informações de produto
 ou loja sejam alteradas posteriormente.
 

--- a/lib/core/constants/enums.dart
+++ b/lib/core/constants/enums.dart
@@ -35,7 +35,7 @@ enum ModerationStatus {
   final String displayName;
 }
 
-// Categoria de estabelecimento
+// Categoria de comércio
 enum StoreCategory {
   supermarket('supermarket', 'Supermercado'),
   hypermarket('hypermarket', 'Hipermercado'),

--- a/lib/presentation/pages/price/add_price_page.dart
+++ b/lib/presentation/pages/price/add_price_page.dart
@@ -226,13 +226,13 @@ class _AddPricePageState extends State<AddPricePage> {
                 controller: _storeController,
                 readOnly: true,
                 decoration: const InputDecoration(
-                  labelText: 'Estabelecimento',
+                  labelText: 'Com\u00e9rcio',
                   prefixIcon: Icon(Icons.store),
                   suffixIcon: Icon(Icons.search),
                 ),
                 onTap: _selectStore,
                 validator: (_) =>
-                    _selectedStore == null ? 'Selecione o estabelecimento' : null,
+                    _selectedStore == null ? 'Selecione o com\u00e9rcio' : null,
               ),
               if (_nearbyStores.isNotEmpty) ...[
                 const SizedBox(height: AppTheme.paddingSmall),

--- a/lib/presentation/pages/price/price_detail_page.dart
+++ b/lib/presentation/pages/price/price_detail_page.dart
@@ -75,7 +75,7 @@ class PriceDetailPage extends StatelessWidget {
                   style: Theme.of(context).textTheme.titleLarge,
                 ),
                 const SizedBox(height: AppTheme.paddingMedium),
-                Text('Estabelecimento: $storeName'),
+                Text('Com\u00e9rcio: $storeName'),
                 const SizedBox(height: AppTheme.paddingMedium),
                 Text(
                   'R\$ ${(data['price'] as num).toStringAsFixed(2)}',

--- a/lib/presentation/pages/store/add_store_page.dart
+++ b/lib/presentation/pages/store/add_store_page.dart
@@ -45,7 +45,7 @@ class _AddStorePageState extends State<AddStorePage> {
         await FirebaseFirestore.instance.collection('stores').add(data);
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Estabelecimento cadastrado')),
+          const SnackBar(content: Text('Com\u00e9rcio cadastrado')),
         );
         Navigator.pop(context);
       } catch (e) {
@@ -82,7 +82,7 @@ class _AddStorePageState extends State<AddStorePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Novo Estabelecimento'),
+        title: const Text('Novo Com\u00e9rcio'),
       ),
       body: Padding(
         padding: const EdgeInsets.all(AppTheme.paddingLarge),

--- a/lib/presentation/pages/store/store_detail_page.dart
+++ b/lib/presentation/pages/store/store_detail_page.dart
@@ -6,7 +6,7 @@ import '../../../core/themes/app_theme.dart';
 import '../../../core/constants/app_constants.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/store_favorites_provider.dart';
-// Página de detalhes exibe apenas informações do estabelecimento.
+// Página de detalhes exibe apenas informações do comércio.
 
 class StoreDetailPage extends ConsumerWidget {
   final DocumentSnapshot store;
@@ -20,7 +20,7 @@ class StoreDetailPage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(data['name'] ?? 'Estabelecimento'),
+        title: Text(data['name'] ?? 'Comércio'),
         actions: [
           IconButton(
             icon: Icon(
@@ -78,8 +78,8 @@ class StoreDetailPage extends ConsumerWidget {
     final confirm = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Excluir Estabelecimento'),
-        content: const Text('Tem certeza que deseja excluir este estabelecimento?'),
+        title: const Text('Excluir Comércio'),
+        content: const Text('Tem certeza que deseja excluir este comércio?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
@@ -97,7 +97,7 @@ class StoreDetailPage extends ConsumerWidget {
       if (context.mounted) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Estabelecimento exclu\u00eddo')),
+          const SnackBar(content: Text('Com\u00e9rcio exclu\u00eddo')),
         );
       }
     }

--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -21,7 +21,7 @@ class StorePricesPage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(data['name'] ?? 'Estabelecimento'),
+        title: Text(data['name'] ?? 'Com\u00e9rcio'),
         actions: [
           IconButton(
             icon: Icon(
@@ -64,7 +64,7 @@ class StorePricesPage extends ConsumerWidget {
           }
           final docs = snapshot.data?.docs ?? [];
           if (docs.isEmpty) {
-            return const Center(child: Text('Nenhum preço para este estabelecimento'));
+            return const Center(child: Text('Nenhum preço para este comércio'));
           }
 
           final Map<String, DocumentSnapshot> latest = {};
@@ -135,8 +135,8 @@ class StorePricesPage extends ConsumerWidget {
     final confirm = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Excluir Estabelecimento'),
-        content: const Text('Tem certeza que deseja excluir este estabelecimento?'),
+        title: const Text('Excluir Comércio'),
+        content: const Text('Tem certeza que deseja excluir este comércio?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
@@ -154,7 +154,7 @@ class StorePricesPage extends ConsumerWidget {
       if (context.mounted) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Estabelecimento excluído')),
+          const SnackBar(content: Text('Comércio excluído')),
         );
       }
     }

--- a/lib/presentation/pages/store/store_search_page.dart
+++ b/lib/presentation/pages/store/store_search_page.dart
@@ -32,7 +32,7 @@ class _StoreSearchPageState extends ConsumerState<StoreSearchPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Buscar Estabelecimentos'),
+        title: const Text('Buscar Com\u00e9rcios'),
       ),
       body: Column(
         children: [
@@ -41,7 +41,7 @@ class _StoreSearchPageState extends ConsumerState<StoreSearchPage> {
             child: TextField(
               controller: _controller,
               decoration: InputDecoration(
-                hintText: 'Buscar estabelecimentos...',
+                hintText: 'Buscar com\u00e9rcios...',
                 prefixIcon: const Icon(Icons.search),
                 suffixIcon: IconButton(
                   icon: const Icon(Icons.clear),
@@ -60,7 +60,7 @@ class _StoreSearchPageState extends ConsumerState<StoreSearchPage> {
                 }
                 final docs = snapshot.data?.docs ?? [];
                 if (docs.isEmpty) {
-                  return const Center(child: Text('Nenhum estabelecimento encontrado'));
+                  return const Center(child: Text('Nenhum com\u00e9rcio encontrado'));
                 }
                 final sortedDocs = docs.toList()
                   ..sort((a, b) {


### PR DESCRIPTION
## Summary
- update UI texts to use "Comércio" instead of "Estabelecimento"
- adjust README terminology
- update store category comment

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685411943e28832fa0ed3ed4d4fd2c78