### PR TITLE
Fix null-aware index syntax for older Dart

### DIFF
--- a/lib/presentation/pages/product/product_prices_page.dart
+++ b/lib/presentation/pages/product/product_prices_page.dart
@@ -126,9 +126,15 @@ class _ProductPricesPageState extends ConsumerState<ProductPricesPage> {
                       '${Formatters.formatPrice((priceData['price'] as num).toDouble())}');
 
               final storeData = storeId != null ? _storeInfo[storeId] : null;
-              final imageUrl = (storeData?['image_url'] as String?)?.isNotEmpty == true
-                  ? storeData?['image_url']
-                  : storeData?['map_image_url'] as String?;
+              final storeImageUrl = storeData != null
+                  ? storeData['image_url'] as String?
+                  : null;
+              final mapImageUrl = storeData != null
+                  ? storeData['map_image_url'] as String?
+                  : null;
+              final imageUrl = (storeImageUrl != null && storeImageUrl.isNotEmpty)
+                  ? storeImageUrl
+                  : mapImageUrl;
 
               return ListTile(
                 leading: imageUrl != null && imageUrl.isNotEmpty

--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -197,9 +197,10 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                     final productName = priceData['product_name'] as String? ?? '';
                     final productId = priceData['product_id'] as String?;
                     final info = productId != null ? _productInfo[productId] : null;
-                    final imageUrl = info?['image_url'] as String?;
-                    final volume = info?['volume'];
-                    final unit = info?['unit'];
+                    final String? imageUrl =
+                        info != null ? info['image_url'] as String? : null;
+                    final volume = info != null ? info['volume'] : null;
+                    final unit = info != null ? info['unit'] : null;
                     var label = productName;
                     if (volume != null && unit != null && unit != 'un') {
                       label = '$productName (${volume.toString()} $unit)';


### PR DESCRIPTION
## Summary
- avoid using `collection?[]` syntax in product prices page
- avoid using `collection?[]` syntax in store prices page

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685432527f94832fbd98dad783727a83