### PR TITLE
Add edit option for products

### DIFF
--- a/lib/presentation/pages/product/product_detail_page.dart
+++ b/lib/presentation/pages/product/product_detail_page.dart
@@ -1,18 +1,37 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/auth_provider.dart';
+import '../admin/edit_product_page.dart';
 
 import '../../../core/themes/app_theme.dart';
 
-class ProductDetailPage extends StatelessWidget {
+class ProductDetailPage extends ConsumerWidget {
   final DocumentSnapshot product;
   const ProductDetailPage({required this.product, super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final data = product.data() as Map<String, dynamic>;
+    final isAdmin = ref.watch(isAdminProvider);
     return Scaffold(
       appBar: AppBar(
         title: Text(data['name'] ?? 'Produto'),
+        actions: [
+          if (isAdmin)
+            IconButton(
+              icon: const Icon(Icons.edit),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => EditProductPage(document: product),
+                  ),
+                );
+              },
+            ),
+        ],
       ),
       body: ListView(
         children: [


### PR DESCRIPTION
## Summary
- allow admins to edit product details directly from the product detail page

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter test integration_test/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685462bd5108832fba82cda6913bad43