### PR TITLE
Fix null return from getList

### DIFF
--- a/lib/presentation/providers/shopping_list_provider.dart
+++ b/lib/presentation/providers/shopping_list_provider.dart
@@ -56,7 +56,12 @@ class ShoppingListNotifier extends StateNotifier<List<ShoppingList>> {
     ];
   }
 
-  ShoppingList? getList(String id) => state.firstWhere((e) => e.id == id, orElse: () => null);
+  ShoppingList? getList(String id) {
+    for (final list in state) {
+      if (list.id == id) return list;
+    }
+    return null;
+  }
 
   Map<String, double> totalsByStore(String listId) {
     final list = getList(listId);


### PR DESCRIPTION
## Summary
- prevent returning null from `getList` by manually searching the list

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854834a4750832f8a58b8094b66de45