### PR TITLE
Add comprehensive test suite

### DIFF
--- a/test/firebase_options_test.dart
+++ b/test/firebase_options_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:precinho_app/firebase_options.dart';
+
+void main() {
+  group('DefaultFirebaseOptions', () {
+    test('returns android options when platform is android', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(DefaultFirebaseOptions.currentPlatform, DefaultFirebaseOptions.android);
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    test('returns ios options when platform is ios', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      expect(DefaultFirebaseOptions.currentPlatform, DefaultFirebaseOptions.ios);
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    test('web options constant is accessible', () {
+      expect(DefaultFirebaseOptions.web.apiKey.isNotEmpty, isTrue);
+    });
+  });
+}

--- a/test/places_service_test.dart
+++ b/test/places_service_test.dart
@@ -1,0 +1,23 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mockito/mockito.dart';
+import 'package:precinho_app/data/datasources/places_service.dart';
+
+class MockHttpClient extends Mock implements http.Client {}
+
+void main() {
+  test('searchPlacesByName returns results from API', () async {
+    final client = MockHttpClient();
+    final service = PlacesService(client: client);
+
+    const responseBody = '{"results": [{"place_id": "1", "name": "Store", "formatted_address": "Street", "geometry": {"location": {"lat": 0, "lng": 0}}}] }';
+    when(client.get(any)).thenAnswer((_) async => http.Response(responseBody, 200));
+
+    final results = await service.searchPlacesByName(name: 'Store');
+
+    expect(results, isNotEmpty);
+    expect(results.first.id, '1');
+  });
+});

--- a/test/price_entity_test.dart
+++ b/test/price_entity_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:precinho_app/domain/entities/price.dart';
+import 'package:precinho_app/core/constants/enums.dart';
+
+void main() {
+  test('copyWith and computed getters', () {
+    final now = DateTime.now();
+    final price = Price(
+      id: '1',
+      productId: 'p1',
+      storeId: 's1',
+      userId: 'u1',
+      value: 10,
+      productName: 'Banana',
+      storeName: 'Loja',
+      createdAt: now.subtract(const Duration(days: 2)),
+      isApproved: true,
+      status: ModerationStatus.approved,
+      updatedAt: now,
+      isPromotional: true,
+    );
+
+    final updated = price.copyWith(value: 12);
+    expect(updated.value, 12);
+
+    expect(price.hasImage, isFalse);
+    expect(price.formattedValue, 'R\$ 10,00');
+    expect(price.ageInDays >= 2, isTrue);
+  });
+}

--- a/test/store_favorites_provider_test.dart
+++ b/test/store_favorites_provider_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:precinho_app/presentation/providers/store_favorites_provider.dart';
+
+void main() {
+  test('toggle favorite adds and removes store', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final notifier = container.read(storeFavoritesProvider.notifier);
+
+    expect(container.read(storeFavoritesProvider).contains('1'), isFalse);
+
+    notifier.toggleFavorite('1');
+    expect(container.read(storeFavoritesProvider).contains('1'), isTrue);
+
+    notifier.toggleFavorite('1');
+    expect(container.read(storeFavoritesProvider).contains('1'), isFalse);
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,55 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:precinho_app/main.dart';
+import 'package:precinho_app/presentation/pages/auth/login_page.dart';
+import 'package:precinho_app/presentation/providers/auth_provider.dart';
+import 'package:precinho_app/data/datasources/auth_service.dart';
+import 'package:precinho_app/data/models/user_model.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('renders login page when not authenticated', (tester) async {
+    final authService = _FakeAuthService();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [authServiceProvider.overrideWithValue(authService)],
+        child: const PrecinhApp(),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
     await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.byType(LoginPage), findsOneWidget);
   });
+}
+
+class _FakeAuthService implements AuthService {
+  @override
+  Stream<UserModel?> get authStateChanges => const Stream.empty();
+
+  @override
+  Future<UserModel?> getCurrentUser() async => null;
+
+  @override
+  Future<void> resetPassword(String email) async {}
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<UserModel> signInWithEmail(String email, String password) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<UserModel> signInWithGoogle() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<UserModel> signUpWithEmail(String email, String password, String name) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> updateProfile(String name, String? photoUrl) async {}
 }


### PR DESCRIPTION
## Summary
- expand widget test to use provider overrides
- add tests for Firebase options
- cover places service and data entities
- add store favorites provider tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854866917ac832fb03d1b84e4cd483d