### PR TITLE
Remove store images

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,6 @@ class Store {
   final String? cnpj;
   final double latitude;
   final double longitude;
-  final String? imageUrl;
-  final String? mapImageUrl;
   final StoreCategory category;
   final bool isApproved;
   final String userId;

--- a/lib/domain/entities/store.dart
+++ b/lib/domain/entities/store.dart
@@ -8,8 +8,6 @@ class Store extends Equatable {
   final String? cnpj;
   final double latitude;
   final double longitude;
-  final String? imageUrl;
-  final String? mapImageUrl;
   final StoreCategory category;
   final bool isApproved;
   final ModerationStatus status;
@@ -30,8 +28,6 @@ class Store extends Equatable {
     this.cnpj,
     required this.latitude,
     required this.longitude,
-    this.imageUrl,
-    this.mapImageUrl,
     required this.category,
     required this.isApproved,
     required this.status,
@@ -53,8 +49,6 @@ class Store extends Equatable {
     String? cnpj,
     double? latitude,
     double? longitude,
-    String? imageUrl,
-    String? mapImageUrl,
     StoreCategory? category,
     bool? isApproved,
     ModerationStatus? status,
@@ -75,8 +69,6 @@ class Store extends Equatable {
       cnpj: cnpj ?? this.cnpj,
       latitude: latitude ?? this.latitude,
       longitude: longitude ?? this.longitude,
-      imageUrl: imageUrl ?? this.imageUrl,
-      mapImageUrl: mapImageUrl ?? this.mapImageUrl,
       category: category ?? this.category,
       isApproved: isApproved ?? this.isApproved,
       status: status ?? this.status,
@@ -92,10 +84,6 @@ class Store extends Equatable {
     );
   }
 
-  bool get hasImage {
-    return (imageUrl != null && imageUrl!.isNotEmpty) ||
-        (mapImageUrl != null && mapImageUrl!.isNotEmpty);
-  }
   bool get hasRating => rating != null && rating! > 0;
   bool get hasContact => phoneNumber != null || website != null;
 
@@ -107,8 +95,6 @@ class Store extends Equatable {
         cnpj,
         latitude,
         longitude,
-        imageUrl,
-        mapImageUrl,
         category,
         isApproved,
         status,

--- a/lib/presentation/pages/product/product_prices_page.dart
+++ b/lib/presentation/pages/product/product_prices_page.dart
@@ -137,25 +137,12 @@ class _ProductPricesPageState extends ConsumerState<ProductPricesPage> {
                       '${Formatters.formatPrice((priceData['price'] as num).toDouble())}');
 
               final storeData = storeId != null ? _storeInfo[storeId] : null;
-              final storeImageUrl = storeData != null
-                  ? storeData['image_url'] as String?
-                  : null;
-              final mapImageUrl = storeData != null
-                  ? storeData['map_image_url'] as String?
-                  : null;
-              final imageUrl = (storeImageUrl != null && storeImageUrl.isNotEmpty)
-                  ? storeImageUrl
-                  : mapImageUrl;
 
               return ListTile(
-                leading: imageUrl != null && imageUrl.isNotEmpty
-                    ? CircleAvatar(
-                        backgroundImage: NetworkImage(imageUrl),
-                      )
-                    : const Icon(
-                        Icons.store,
-                        color: AppTheme.primaryColor,
-                      ),
+                leading: const Icon(
+                  Icons.store,
+                  color: AppTheme.primaryColor,
+                ),
                 title: Text(storeName),
                 trailing: Row(
                   mainAxisSize: MainAxisSize.min,

--- a/lib/presentation/pages/store/add_store_page.dart
+++ b/lib/presentation/pages/store/add_store_page.dart
@@ -1,14 +1,8 @@
-import 'dart:io';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
-import 'package:image_picker/image_picker.dart';
-import 'package:uuid/uuid.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/validators.dart';
-import '../../../core/constants/app_constants.dart';
 import '../../../core/logging/firebase_logger.dart';
 import 'place_search_page.dart';
 import '../../../data/models/place_result.dart';
@@ -27,22 +21,9 @@ class _AddStorePageState extends State<AddStorePage> {
   final _addressController = TextEditingController();
   final _cnpjController = TextEditingController();
   final _placesService = PlacesService();
-  final ImagePicker _picker = ImagePicker();
-  XFile? _imageFile;
   double? _latitude;
   double? _longitude;
   String? _placeId;
-  String? _photoReference;
-
-  Future<void> _pickImage() async {
-    final picked = await _picker.pickImage(source: ImageSource.gallery);
-    if (picked != null) {
-      setState(() {
-        _imageFile = picked;
-      });
-    }
-  }
-
   @override
   void dispose() {
     _nameController.dispose();
@@ -54,27 +35,7 @@ class _AddStorePageState extends State<AddStorePage> {
   Future<void> _submit() async {
     if (_formKey.currentState!.validate()) {
       try {
-        String? imageUrl;
-        if (_imageFile != null) {
-          final id = const Uuid().v4();
-          final ref = FirebaseStorage.instance
-              .ref()
-              .child('store_images/$id.jpg');
-          FirebaseLogger.log('Uploading store image', {'path': ref.fullPath});
-          await ref.putFile(File(_imageFile!.path));
-          imageUrl = await ref.getDownloadURL();
-          FirebaseLogger.log('Store image uploaded', {'url': imageUrl});
-        }
-        if (_photoReference == null && _placeId != null) {
-          try {
-            _photoReference =
-                await _placesService.getPhotoReference(_placeId!);
-          } catch (_) {}
-        }
-
-        final mapImageUrl =
-            _photoReference != null ? _placesService.buildPhotoUrl(_photoReference!) : null;
-
+        
         final data = {
           'name': _nameController.text.trim(),
           'address': _addressController.text.trim(),
@@ -84,8 +45,6 @@ class _AddStorePageState extends State<AddStorePage> {
             'longitude': _longitude,
             'place_id': _placeId,
           },
-          'map_image_url': mapImageUrl,
-          'image_url': imageUrl,
           'created_at': Timestamp.now(),
           'user_id': FirebaseAuth.instance.currentUser?.uid,
           'status': 'active',
@@ -126,7 +85,6 @@ class _AddStorePageState extends State<AddStorePage> {
         _latitude = result.latitude;
         _longitude = result.longitude;
         _placeId = result.id;
-        _photoReference = result.photoReference;
       });
     }
   }
@@ -175,20 +133,6 @@ class _AddStorePageState extends State<AddStorePage> {
                 validator: Validators.validateCnpj,
               ),
               const SizedBox(height: AppTheme.paddingMedium),
-              if (_imageFile != null)
-                Padding(
-                  padding: const EdgeInsets.only(bottom: AppTheme.paddingMedium),
-                  child: Image.file(
-                    File(_imageFile!.path),
-                    height: 150,
-                    fit: BoxFit.cover,
-                  ),
-                ),
-              OutlinedButton.icon(
-                onPressed: _pickImage,
-                icon: const Icon(Icons.photo),
-                label: const Text('Selecionar Foto'),
-              ),
               const SizedBox(height: AppTheme.paddingLarge),
               SizedBox(
                 width: double.infinity,

--- a/lib/presentation/pages/store/store_detail_page.dart
+++ b/lib/presentation/pages/store/store_detail_page.dart
@@ -55,15 +55,7 @@ class StoreDetailPage extends ConsumerWidget {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (data['map_image_url'] != null &&
-              (data['map_image_url'] as String).isNotEmpty)
-            Image.network(
-              data['map_image_url'],
-              width: double.infinity,
-              height: 200,
-              fit: BoxFit.cover,
-            )
-          else if (data['latitude'] != null && data['longitude'] != null)
+          if (data['latitude'] != null && data['longitude'] != null)
             Image.network(
               'https://maps.googleapis.com/maps/api/staticmap?center=${data['latitude']},${data['longitude']}&zoom=16&size=600x200&markers=color:red%7C${data['latitude']},${data['longitude']}&key=${AppConstants.googleMapsApiKey}',
               width: double.infinity,

--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
-import '../../../core/constants/app_constants.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/store_favorites_provider.dart';
 import '../price/add_price_page.dart';
@@ -103,27 +102,6 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if ((data['image_url'] as String?)?.isNotEmpty == true)
-            Image.network(
-              data['image_url'],
-              width: double.infinity,
-              height: 200,
-              fit: BoxFit.cover,
-            )
-          else if ((data['map_image_url'] as String?)?.isNotEmpty == true)
-            Image.network(
-              data['map_image_url'],
-              width: double.infinity,
-              height: 200,
-              fit: BoxFit.cover,
-            )
-          else if (data['latitude'] != null && data['longitude'] != null)
-            Image.network(
-              'https://maps.googleapis.com/maps/api/staticmap?center=${data['latitude']},${data['longitude']}&zoom=16&size=600x200&markers=color:red%7C${data['latitude']},${data['longitude']}&key=${AppConstants.googleMapsApiKey}',
-              width: double.infinity,
-              height: 200,
-              fit: BoxFit.cover,
-            ),
           Padding(
             padding: const EdgeInsets.all(AppTheme.paddingMedium),
             child: Text(data['address'] ?? ''),

--- a/lib/presentation/pages/store/store_search_page.dart
+++ b/lib/presentation/pages/store/store_search_page.dart
@@ -75,19 +75,12 @@ class _StoreSearchPageState extends ConsumerState<StoreSearchPage> {
                     final doc = sortedDocs[index];
                     final data = doc.data() as Map<String, dynamic>;
                     final isFav = favorites.contains(doc.id);
-                    final imageUrl = (data['image_url'] as String?)?.isNotEmpty == true
-                        ? data['image_url']
-                        : data['map_image_url'] as String?;
                     return Card(
                       child: ListTile(
-                        leading: imageUrl != null && imageUrl.isNotEmpty
-                            ? CircleAvatar(
-                                backgroundImage: NetworkImage(imageUrl),
-                              )
-                            : const Icon(
-                                Icons.store,
-                                color: AppTheme.primaryColor,
-                              ),
+                        leading: const Icon(
+                          Icons.store,
+                          color: AppTheme.primaryColor,
+                        ),
                         title: Text(data['name'] ?? 'Loja'),
                         subtitle: Text(data['address'] ?? ''),
                         trailing: IconButton(


### PR DESCRIPTION
## Summary
- drop image and map fields from Store model
- update add/edit store pages to remove photo handling
- clean store search and product prices lists to only show icons
- remove store photos/map from store prices page
- tweak store detail page to always use dynamic map
- update README data model

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68548ba388a0832fad07955f02a626a6