### PR TITLE
Implement shopping list persistence

### DIFF
--- a/lib/data/datasources/shopping_list_storage.dart
+++ b/lib/data/datasources/shopping_list_storage.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/shopping_list_model.dart';
+
+class ShoppingListStorage {
+  static const _listsKey = 'shopping_lists';
+
+  Future<List<ShoppingListModel>> loadLists() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString(_listsKey);
+    if (jsonString == null) return [];
+    final List<dynamic> data = json.decode(jsonString) as List<dynamic>;
+    return data
+        .map((e) => ShoppingListModel.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<void> saveLists(List<ShoppingListModel> lists) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = lists.map((e) => e.toJson()).toList();
+    await prefs.setString(_listsKey, json.encode(data));
+  }
+}

--- a/lib/data/models/shopping_list_model.dart
+++ b/lib/data/models/shopping_list_model.dart
@@ -1,0 +1,136 @@
+import '../../domain/entities/shopping_list.dart';
+import '../../core/constants/enums.dart';
+
+class ShoppingListItemModel extends ShoppingListItem {
+  const ShoppingListItemModel({
+    required super.id,
+    required super.productId,
+    required super.productName,
+    required super.quantity,
+    super.price,
+    super.storeId,
+    super.storeName,
+    required super.isCompleted,
+    super.notes,
+    required super.createdAt,
+    required super.updatedAt,
+  });
+
+  factory ShoppingListItemModel.fromJson(Map<String, dynamic> json) {
+    return ShoppingListItemModel(
+      id: json['id'] as String,
+      productId: json['product_id'] as String,
+      productName: json['product_name'] as String,
+      quantity: (json['quantity'] as num).toDouble(),
+      price: (json['price'] as num?)?.toDouble(),
+      storeId: json['store_id'] as String?,
+      storeName: json['store_name'] as String?,
+      isCompleted: json['is_completed'] as bool? ?? false,
+      notes: json['notes'] as String?,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'product_id': productId,
+      'product_name': productName,
+      'quantity': quantity,
+      'price': price,
+      'store_id': storeId,
+      'store_name': storeName,
+      'is_completed': isCompleted,
+      'notes': notes,
+      'created_at': createdAt.toIso8601String(),
+      'updated_at': updatedAt.toIso8601String(),
+    };
+  }
+
+  factory ShoppingListItemModel.fromEntity(ShoppingListItem item) {
+    return ShoppingListItemModel(
+      id: item.id,
+      productId: item.productId,
+      productName: item.productName,
+      quantity: item.quantity,
+      price: item.price,
+      storeId: item.storeId,
+      storeName: item.storeName,
+      isCompleted: item.isCompleted,
+      notes: item.notes,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    );
+  }
+}
+
+class ShoppingListModel extends ShoppingList {
+  const ShoppingListModel({
+    required super.id,
+    required super.userId,
+    required super.name,
+    required super.items,
+    required super.status,
+    required super.createdAt,
+    required super.updatedAt,
+    super.description,
+    super.budget,
+    super.metadata,
+  });
+
+  factory ShoppingListModel.fromJson(Map<String, dynamic> json) {
+    return ShoppingListModel(
+      id: json['id'] as String,
+      userId: json['user_id'] as String,
+      name: json['name'] as String,
+      items: (json['items'] as List<dynamic>)
+          .map((e) =>
+              ShoppingListItemModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      status: ShoppingListStatus.values.firstWhere(
+        (s) => s.value == json['status'],
+        orElse: () => ShoppingListStatus.active,
+      ),
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
+      description: json['description'] as String?,
+      budget: (json['budget'] as num?)?.toDouble(),
+      metadata: json['metadata'] as Map<String, dynamic>?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'user_id': userId,
+      'name': name,
+      'items': items
+          .map((e) => ShoppingListItemModel.fromEntity(e).toJson())
+          .toList(),
+      'status': status.value,
+      'created_at': createdAt.toIso8601String(),
+      'updated_at': updatedAt.toIso8601String(),
+      'description': description,
+      'budget': budget,
+      'metadata': metadata,
+    };
+  }
+
+  factory ShoppingListModel.fromEntity(ShoppingList list) {
+    return ShoppingListModel(
+      id: list.id,
+      userId: list.userId,
+      name: list.name,
+      items: list.items
+          .map((e) => ShoppingListItemModel.fromEntity(e))
+          .toList(),
+      status: list.status,
+      createdAt: list.createdAt,
+      updatedAt: list.updatedAt,
+      description: list.description,
+      budget: list.budget,
+      metadata: list.metadata,
+    );
+  }
+}

--- a/test/shopping_list_provider_test.dart
+++ b/test/shopping_list_provider_test.dart
@@ -1,8 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:precinho_app/presentation/providers/shopping_list_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:precinho_app/presentation/providers/shopping_list_provider.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
   test('create list and add item', () {
     final container = ProviderContainer();
     addTearDown(container.dispose);


### PR DESCRIPTION
## Summary
- serialize shopping lists and items
- store shopping lists using `SharedPreferences`
- load lists on startup and save on update
- update provider tests with mocked prefs

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548e85bb78832f8f9d29a2aef0a7a5