### PR TITLE
Fix image layout in store price cards

### DIFF
--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -206,7 +206,7 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                     crossAxisCount: 3,
                     crossAxisSpacing: AppTheme.paddingMedium,
                     mainAxisSpacing: AppTheme.paddingMedium,
-                    childAspectRatio: 1.4,
+                    childAspectRatio: 0.8,
                   ),
                   itemCount: prices.length,
                   itemBuilder: (context, index) {
@@ -246,7 +246,7 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                                             AppTheme.radiusSmall),
                                         child: Image.network(
                                           imageUrl,
-                                          fit: BoxFit.cover,
+                                          fit: BoxFit.contain,
                                           width: double.infinity,
                                         ),
                                       )


### PR DESCRIPTION
## Summary
- ensure price cards have more vertical space
- resize product images instead of cropping them

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549f665324832fa6b988d7b41b0468