### PR TITLE
Implement Firestore storage and multi-store selection

### DIFF
--- a/lib/presentation/providers/shopping_list_provider.dart
+++ b/lib/presentation/providers/shopping_list_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import '../../domain/entities/shopping_list.dart';
 import '../../core/constants/enums.dart';
 import '../../data/models/shopping_list_model.dart';
@@ -20,9 +21,10 @@ class ShoppingListNotifier extends StateNotifier<List<ShoppingList>> {
 
   String createList(String name) {
     final id = DateTime.now().millisecondsSinceEpoch.toString();
+    final userId = FirebaseAuth.instance.currentUser?.uid ?? 'local';
     final list = ShoppingList(
       id: id,
-      userId: 'local',
+      userId: userId,
       name: name,
       items: const [],
       status: ShoppingListStatus.active,


### PR DESCRIPTION
## Summary
- store shopping lists in Firestore instead of shared preferences
- obtain current user's uid when creating lists
- allow selecting multiple stores with checkboxes

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552f719720832fb1d631abe8b14e0b