### PR TITLE
Refactor shopping list with store integration

### DIFF
--- a/lib/presentation/pages/shopping_list/shopping_list_detail_page.dart
+++ b/lib/presentation/pages/shopping_list/shopping_list_detail_page.dart
@@ -1,9 +1,11 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:geolocator/geolocator.dart';
 
 import '../../../core/themes/app_theme.dart';
 import '../../providers/shopping_list_provider.dart';
+import '../../providers/store_favorites_provider.dart';
 import '../product/product_search_page.dart';
 
 class ShoppingListDetailPage extends ConsumerStatefulWidget {
@@ -15,14 +17,101 @@ class ShoppingListDetailPage extends ConsumerStatefulWidget {
 }
 
 class _ShoppingListDetailPageState extends ConsumerState<ShoppingListDetailPage> {
-  final Set<String> _selectedStores = {};
+  final List<DocumentSnapshot> _stores = [];
+  bool _isLoadingStores = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadStores();
+  }
+
+  Future<void> _loadStores() async {
+    setState(() {
+      _isLoadingStores = true;
+    });
+
+    final favorites = ref.read(storeFavoritesProvider);
+    final collection = FirebaseFirestore.instance.collection('stores');
+
+    final Map<String, DocumentSnapshot> found = {};
+
+    for (final id in favorites) {
+      try {
+        final doc = await collection.doc(id).get();
+        if (doc.exists) {
+          found[id] = doc;
+        }
+      } catch (_) {}
+    }
+
+    try {
+      final permission = await Geolocator.requestPermission();
+      if (permission != LocationPermission.denied &&
+          permission != LocationPermission.deniedForever) {
+        final position = await Geolocator.getCurrentPosition();
+        final snap = await collection.get();
+        const radius = 2000.0;
+        for (final doc in snap.docs) {
+          final data = doc.data();
+          final lat = (data['latitude'] as num?)?.toDouble();
+          final lng = (data['longitude'] as num?)?.toDouble();
+          if (lat == null || lng == null) continue;
+          final dist = Geolocator.distanceBetween(
+            position.latitude,
+            position.longitude,
+            lat,
+            lng,
+          );
+          if (dist <= radius && !found.containsKey(doc.id)) {
+            found[doc.id] = doc;
+          }
+        }
+      }
+    } catch (_) {}
+
+    setState(() {
+      _stores
+        ..clear()
+        ..addAll(found.values);
+      _isLoadingStores = false;
+    });
+  }
+
+  Future<void> _applyStore(DocumentSnapshot store) async {
+    final notifier = ref.read(shoppingListProvider.notifier);
+    final list = notifier.getList(widget.listId);
+    if (list == null) return;
+
+    for (final item in list.items) {
+      try {
+        final snap = await FirebaseFirestore.instance
+            .collection('prices')
+            .where('product_id', isEqualTo: item.productId)
+            .where('store_id', isEqualTo: store.id)
+            .where('isApproved', isEqualTo: true)
+            .orderBy('created_at', descending: true)
+            .limit(1)
+            .get();
+        if (snap.docs.isNotEmpty) {
+          final data = snap.docs.first.data();
+          final price = (data['price'] as num?)?.toDouble();
+          notifier.updateItemPrice(
+            listId: widget.listId,
+            productId: item.productId,
+            price: price,
+            storeId: store.id,
+            storeName: data['store_name'] ?? (store.data() as Map<String, dynamic>)['name'],
+          );
+        }
+      } catch (_) {}
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final list = ref.watch(shoppingListProvider).firstWhere((e) => e.id == widget.listId);
     final totals = ref.read(shoppingListProvider.notifier).totalsByStore(widget.listId);
-
-    final storeOptions = totals.keys.toList();
 
     return Scaffold(
       appBar: AppBar(
@@ -45,27 +134,28 @@ class _ShoppingListDetailPageState extends ConsumerState<ShoppingListDetailPage>
             },
           ),
           const Divider(),
-          ...storeOptions.map(
-            (s) {
-              final selected = _selectedStores.contains(s);
-              return CheckboxListTile(
-                value: selected,
-                title: Text(s),
-                secondary: selected
-                    ? Text('R\$ ${totals[s]!.toStringAsFixed(2)}')
-                    : null,
-                onChanged: (value) {
-                  setState(() {
-                    if (value ?? false) {
-                      _selectedStores.add(s);
-                    } else {
-                      _selectedStores.remove(s);
-                    }
-                  });
-                },
-              );
-            },
-          ),
+          if (_isLoadingStores)
+            const Center(child: CircularProgressIndicator())
+          else if (_stores.isNotEmpty) ...[
+            Text(
+              'Estabelecimentos',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: AppTheme.paddingSmall),
+            Wrap(
+              spacing: AppTheme.paddingSmall,
+              children: _stores
+                  .map(
+                    (doc) => ActionChip(
+                      label: Text(
+                        (doc.data() as Map<String, dynamic>)['name'] ?? 'Loja',
+                      ),
+                      onPressed: () => _applyStore(doc),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
         ],
       ),
       floatingActionButton: FloatingActionButton(

--- a/lib/presentation/providers/shopping_list_provider.dart
+++ b/lib/presentation/providers/shopping_list_provider.dart
@@ -71,8 +71,40 @@ class ShoppingListNotifier extends StateNotifier<List<ShoppingList>> {
         else
           l
     ];
-    _storage.saveLists(
-        state.map((e) => ShoppingListModel.fromEntity(e)).toList());
+      _storage.saveLists(
+          state.map((e) => ShoppingListModel.fromEntity(e)).toList());
+    }
+
+  void updateItemPrice({
+    required String listId,
+    required String productId,
+    double? price,
+    String? storeId,
+    String? storeName,
+  }) {
+    state = [
+      for (final l in state)
+        if (l.id == listId)
+          l.copyWith(
+            items: [
+              for (final item in l.items)
+                if (item.productId == productId)
+                  item.copyWith(
+                    price: price,
+                    storeId: storeId,
+                    storeName: storeName,
+                    updatedAt: DateTime.now(),
+                  )
+                else
+                  item,
+            ],
+            updatedAt: DateTime.now(),
+          )
+        else
+          l
+    ];
+    _storage
+        .saveLists(state.map((e) => ShoppingListModel.fromEntity(e)).toList());
   }
 
   ShoppingList? getList(String id) {

--- a/test/shopping_list_provider_test.dart
+++ b/test/shopping_list_provider_test.dart
@@ -29,4 +29,27 @@ void main() {
     final totals = notifier.totalsByStore(listId);
     expect(totals['Loja'], 6);
   });
+
+  test('update item price', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(shoppingListProvider.notifier);
+    final listId = notifier.createList('Teste');
+    notifier.addProductToList(
+      listId: listId,
+      productId: '1',
+      productName: 'Banana',
+      quantity: 1,
+    );
+    notifier.updateItemPrice(
+      listId: listId,
+      productId: '1',
+      price: 2.5,
+      storeId: 's1',
+      storeName: 'Loja',
+    );
+    final list = container.read(shoppingListProvider).firstWhere((l) => l.id == listId);
+    expect(list.items.first.price, 2.5);
+    expect(list.items.first.storeId, 's1');
+  });
 }


### PR DESCRIPTION
## Summary
- allow updating individual item prices in the provider
- suggest nearby or favorite stores below shopping lists
- clicking a store updates items with that store's latest prices
- add unit test for price update

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855352dad3c832fbd58d795591c1497