### PR TITLE
Fix shopping list price update with store validation

### DIFF
--- a/lib/presentation/providers/shopping_list_provider.dart
+++ b/lib/presentation/providers/shopping_list_provider.dart
@@ -89,7 +89,8 @@ class ShoppingListNotifier extends StateNotifier<List<ShoppingList>> {
           l.copyWith(
             items: [
               for (final item in l.items)
-                if (item.productId == productId)
+                if (item.productId == productId &&
+                    (item.storeId == storeId || item.storeId == null))
                   item.copyWith(
                     price: price,
                     storeId: storeId,


### PR DESCRIPTION
## Summary
- ensure `ShoppingListNotifier.updateItemPrice` checks both product and store IDs when updating an item price

## Testing
- `flutter test` *(fails: `flutter: command not found`)*
- `dart test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68558ba9b97c832f924f4e2e078f8059