### PR TITLE
Fix clearing prices when store changes

### DIFF
--- a/lib/domain/entities/shopping_list.dart
+++ b/lib/domain/entities/shopping_list.dart
@@ -30,12 +30,14 @@ class ShoppingListItem extends Equatable {
     required this.updatedAt,
   });
 
+  static const _undefined = Object();
+
   ShoppingListItem copyWith({
     String? id,
     String? productId,
     String? productName,
     double? quantity,
-    double? price,
+    Object? price = _undefined,
     String? storeId,
     String? storeName,
     bool? isCompleted,
@@ -49,7 +51,7 @@ class ShoppingListItem extends Equatable {
       productId: productId ?? this.productId,
       productName: productName ?? this.productName,
       quantity: quantity ?? this.quantity,
-      price: price ?? this.price,
+      price: identical(price, _undefined) ? this.price : price as double?,
       storeId: storeId ?? this.storeId,
       storeName: storeName ?? this.storeName,
       isCompleted: isCompleted ?? this.isCompleted,

--- a/test/shopping_list_provider_test.dart
+++ b/test/shopping_list_provider_test.dart
@@ -52,4 +52,27 @@ void main() {
     expect(list.items.first.price, 2.5);
     expect(list.items.first.storeId, 's1');
   });
+
+  test('clear item prices', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(shoppingListProvider.notifier);
+    final listId = notifier.createList('Teste');
+    notifier.addProductToList(
+      listId: listId,
+      productId: '1',
+      productName: 'Banana',
+      quantity: 1,
+      price: 2,
+      storeId: 's1',
+      storeName: 'Loja',
+    );
+
+    notifier.clearPrices(listId);
+
+    final list = container.read(shoppingListProvider).firstWhere((l) => l.id == listId);
+    expect(list.items.first.price, isNull);
+    expect(list.items.first.storeId, isNull);
+    expect(list.items.first.storeName, isNull);
+  });
 }


### PR DESCRIPTION
## Summary
- allow `ShoppingListItem.copyWith` to overwrite price with null
- add test for clearing prices

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685590789858832fac0595c81ffc468a