### PR TITLE
Add page scrolling to price detail page

### DIFF
--- a/lib/presentation/pages/price/price_detail_page.dart
+++ b/lib/presentation/pages/price/price_detail_page.dart
@@ -84,7 +84,7 @@ class PriceDetailPage extends StatelessWidget {
             return const Center(child: CircularProgressIndicator());
           }
 
-          return Padding(
+          return SingleChildScrollView(
             padding: const EdgeInsets.all(AppTheme.paddingLarge),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
## Summary
- enable page scrolling for the price detail page

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter test integration_test/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685590dfdd0c832fac891de6a19cc051