### PR TITLE
Fix store price clearing

### DIFF
--- a/lib/presentation/pages/shopping_list/shopping_list_detail_page.dart
+++ b/lib/presentation/pages/shopping_list/shopping_list_detail_page.dart
@@ -154,6 +154,15 @@ class _ShoppingListDetailPageState extends ConsumerState<ShoppingListDetailPage>
     notifier.clearPrices(widget.listId);
 
     for (final item in list.items.where((e) => !e.isDisabled)) {
+      // Reset value to avoid showing stale data while loading
+      notifier.updateItemPrice(
+        listId: widget.listId,
+        productId: item.productId,
+        price: null,
+        storeId: store.id,
+        storeName: _selectedStoreName,
+      );
+
       try {
         final snap = await FirebaseFirestore.instance
             .collection('prices')
@@ -166,30 +175,18 @@ class _ShoppingListDetailPageState extends ConsumerState<ShoppingListDetailPage>
         if (snap.docs.isNotEmpty) {
           final data = snap.docs.first.data();
           final price = (data['price'] as num?)?.toDouble();
-          notifier.updateItemPrice(
-            listId: widget.listId,
-            productId: item.productId,
-            price: price,
-            storeId: store.id,
-            storeName: _selectedStoreName,
-          );
-        } else {
-          notifier.updateItemPrice(
-            listId: widget.listId,
-            productId: item.productId,
-            price: null,
-            storeId: store.id,
-            storeName: _selectedStoreName,
-          );
+          if (price != null) {
+            notifier.updateItemPrice(
+              listId: widget.listId,
+              productId: item.productId,
+              price: price,
+              storeId: store.id,
+              storeName: _selectedStoreName,
+            );
+          }
         }
       } catch (_) {
-        notifier.updateItemPrice(
-          listId: widget.listId,
-          productId: item.productId,
-          price: null,
-          storeId: store.id,
-          storeName: _selectedStoreName,
-        );
+        // ignore and keep previous null
       }
     }
 

--- a/test/shopping_list_provider_test.dart
+++ b/test/shopping_list_provider_test.dart
@@ -75,4 +75,35 @@ void main() {
     expect(list.items.first.storeId, isNull);
     expect(list.items.first.storeName, isNull);
   });
+
+  test('update item price after clearing retains new store and null price', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(shoppingListProvider.notifier);
+    final listId = notifier.createList('Teste');
+    notifier.addProductToList(
+      listId: listId,
+      productId: '1',
+      productName: 'Banana',
+      quantity: 1,
+      price: 2,
+      storeId: 's1',
+      storeName: 'Loja',
+    );
+
+    notifier.clearPrices(listId);
+    notifier.updateItemPrice(
+      listId: listId,
+      productId: '1',
+      price: null,
+      storeId: 's2',
+      storeName: 'Loja 2',
+    );
+
+    final list = container.read(shoppingListProvider).firstWhere((l) => l.id == listId);
+    final item = list.items.first;
+    expect(item.price, isNull);
+    expect(item.storeId, 's2');
+    expect(item.storeName, 'Loja 2');
+  });
 }


### PR DESCRIPTION
## Summary
- clear each item's price before fetching store data
- test resetting price and store

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a7e52a64832f93f977011b2c04f8