### PR TITLE
Move store management to admin panel

### DIFF
--- a/lib/presentation/pages/admin/admin_home_page.dart
+++ b/lib/presentation/pages/admin/admin_home_page.dart
@@ -4,6 +4,7 @@ import 'add_product_page.dart';
 import 'manage_products_page.dart';
 import 'manage_users_page.dart';
 import 'validate_prices_page.dart';
+import 'manage_stores_page.dart';
 
 class AdminHomePage extends StatelessWidget {
   const AdminHomePage({super.key});
@@ -30,6 +31,19 @@ class AdminHomePage extends StatelessWidget {
               },
               icon: const Icon(Icons.add),
               label: const Text('Adicionar Produto'),
+            ),
+            const SizedBox(height: AppTheme.paddingMedium),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const ManageStoresPage(),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.store),
+              label: const Text('Gerenciar Com\u00e9rcios'),
             ),
             const SizedBox(height: AppTheme.paddingMedium),
             ElevatedButton.icon(

--- a/lib/presentation/pages/admin/manage_stores_page.dart
+++ b/lib/presentation/pages/admin/manage_stores_page.dart
@@ -1,0 +1,98 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../../../core/themes/app_theme.dart';
+import '../store/add_store_page.dart';
+import '../store/edit_store_page.dart';
+import '../../../core/logging/firebase_logger.dart';
+
+class ManageStoresPage extends StatelessWidget {
+  const ManageStoresPage({super.key});
+
+  Future<void> _deleteStore(BuildContext context, DocumentReference doc) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Excluir Comércio'),
+        content: const Text('Tem certeza que deseja excluir este comércio?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Excluir'),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      FirebaseLogger.log('Deleting store', {'path': doc.path});
+      await doc.delete();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Comércio excluído')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Gerenciar Comércios'),
+      ),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('stores')
+            .orderBy('name')
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return const Center(child: Text('Erro ao carregar comércios'));
+          }
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('Nenhum comércio cadastrado'));
+          }
+          return ListView.builder(
+            itemCount: docs.length,
+            itemBuilder: (context, index) {
+              final doc = docs[index];
+              final data = doc.data() as Map<String, dynamic>;
+              return ListTile(
+                leading: const Icon(Icons.store, color: AppTheme.primaryColor),
+                title: Text(data['name'] ?? ''),
+                subtitle: Text(data['address'] ?? ''),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => EditStorePage(document: doc),
+                    ),
+                  );
+                },
+                trailing: IconButton(
+                  icon: const Icon(Icons.delete, color: AppTheme.errorColor),
+                  onPressed: () => _deleteStore(context, doc.reference),
+                ),
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const AddStorePage()),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/store/store_detail_page.dart
+++ b/lib/presentation/pages/store/store_detail_page.dart
@@ -5,9 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../../core/themes/app_theme.dart';
 import '../../../core/constants/app_constants.dart';
-import '../../providers/auth_provider.dart';
 import '../../providers/store_favorites_provider.dart';
-import 'edit_store_page.dart';
 // Página de detalhes exibe apenas informações do comércio.
 
 class StoreDetailPage extends ConsumerWidget {
@@ -18,7 +16,6 @@ class StoreDetailPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final data = store.data() as Map<String, dynamic>;
     final isFav = ref.watch(storeFavoritesProvider).contains(store.id);
-    final isAdmin = ref.watch(isAdminProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -33,23 +30,6 @@ class StoreDetailPage extends ConsumerWidget {
               ref.read(storeFavoritesProvider.notifier).toggleFavorite(store.id);
             },
           ),
-          if (isAdmin)
-            IconButton(
-              icon: const Icon(Icons.edit),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => EditStorePage(document: store),
-                  ),
-                );
-              },
-            ),
-          if (isAdmin)
-            IconButton(
-              icon: const Icon(Icons.delete),
-              onPressed: () => _deleteStore(context),
-            ),
         ],
       ),
       body: Column(
@@ -113,34 +93,6 @@ class StoreDetailPage extends ConsumerWidget {
     );
   }
 
-  Future<void> _deleteStore(BuildContext context) async {
-    final confirm = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Excluir Comércio'),
-        content: const Text('Tem certeza que deseja excluir este comércio?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancelar'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Excluir'),
-          ),
-        ],
-      ),
-    );
-    if (confirm == true) {
-      await store.reference.delete();
-      if (context.mounted) {
-        Navigator.pop(context);
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Com\u00e9rcio exclu\u00eddo')),
-        );
-      }
-    }
-  }
 
   Future<void> _openMaps(
     BuildContext context,

--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -4,12 +4,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
-import '../../providers/auth_provider.dart';
 import '../../providers/store_favorites_provider.dart';
 import '../price/add_price_page.dart';
 import '../price/price_detail_page.dart';
 import 'store_detail_page.dart';
-import 'edit_store_page.dart';
 
 class StorePricesPage extends ConsumerStatefulWidget {
   final DocumentSnapshot store;
@@ -52,7 +50,6 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
   Widget build(BuildContext context) {
     final data = widget.store.data() as Map<String, dynamic>;
     final isFav = ref.watch(storeFavoritesProvider).contains(widget.store.id);
-    final isAdmin = ref.watch(isAdminProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -80,23 +77,6 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
               );
             },
           ),
-          if (isAdmin)
-            IconButton(
-              icon: const Icon(Icons.edit),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => EditStorePage(document: widget.store),
-                  ),
-                );
-              },
-            ),
-          if (isAdmin)
-            IconButton(
-              icon: const Icon(Icons.delete),
-              onPressed: () => _deleteStore(context),
-            ),
         ],
       ),
       body: Column(
@@ -324,32 +304,4 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
     );
   }
 
-  Future<void> _deleteStore(BuildContext context) async {
-    final confirm = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Excluir Comércio'),
-        content: const Text('Tem certeza que deseja excluir este comércio?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancelar'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Excluir'),
-          ),
-        ],
-      ),
-    );
-    if (confirm == true) {
-      await widget.store.reference.delete();
-      if (context.mounted) {
-        Navigator.pop(context);
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Comércio excluído')),
-        );
-      }
-    }
-  }
 }

--- a/lib/presentation/pages/store/store_search_page.dart
+++ b/lib/presentation/pages/store/store_search_page.dart
@@ -3,9 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/themes/app_theme.dart';
-import '../../providers/auth_provider.dart';
 import '../../providers/store_favorites_provider.dart';
-import 'add_store_page.dart';
 import 'store_prices_page.dart';
 
 class StoreSearchPage extends ConsumerStatefulWidget {
@@ -113,20 +111,8 @@ class _StoreSearchPageState extends ConsumerState<StoreSearchPage> {
           ),
         ],
       ),
-      floatingActionButton: ref.watch(isAdminProvider)
-          ? FloatingActionButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => const AddStorePage(),
-                  ),
-                );
-              },
-              child: const Icon(Icons.add),
-            )
-          : null,
-    );
+      // Sem ações de cadastro nesta página
+      );
   }
 
   Query _buildQuery() {


### PR DESCRIPTION
## Summary
- restrict store search page to consultation only
- drop edit/delete actions from store pages
- add admin page to manage stores
- expose store management option on admin home

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a9ec03a8832f95afa25ae7db2169