### PR TITLE
add price next to shopping list items

### DIFF
--- a/lib/presentation/pages/shopping_list/shopping_list_detail_page.dart
+++ b/lib/presentation/pages/shopping_list/shopping_list_detail_page.dart
@@ -276,6 +276,18 @@ class _ShoppingListDetailPageState extends ConsumerState<ShoppingListDetailPage>
                             : null,
                       ),
                     ),
+                    if (_selectedStoreId != null)
+                      Text(
+                        item.price != null
+                            ? Formatters.formatPrice(item.price!)
+                            : '-',
+                        style: item.isDisabled
+                            ? const TextStyle(
+                                decoration: TextDecoration.lineThrough,
+                                color: Colors.grey,
+                              )
+                            : AppTheme.priceTextStyle,
+                      ),
                   ],
                 ),
               );


### PR DESCRIPTION
## Summary
- show price for the selected store beside each item on the shopping list

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855abafc29c832fa9a5bfc174d2499b