### PR TITLE
Add web build step to Firebase deploy workflow

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -12,6 +12,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Configurar Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Instalar dependências
+        run: flutter pub get
+
+      - name: Gerar build web
+        run: flutter build web --release
+
       - name: Configurar Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Summary
- ensure Flutter setup and build web artifacts before deployment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685622998f38832fb18950da6a15a78c