### PR TITLE
Fix Firebase deploy workflow

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -29,3 +29,4 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           projectId: precinho-dd1c9
+          channelId: live


### PR DESCRIPTION
## Summary
- specify `channelId` when deploying to Firebase Hosting

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685677488ae8832f9a80f3e89a0be6a9