### PR TITLE
Fix dotenv fallback

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -3,18 +3,12 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class AppConfig {
   static Future<void> load({String fileName = '.env'}) async {
-    try {
-      if (await File(fileName).exists()) {
-        await dotenv.load(fileName: fileName);
-      } else {
-        dotenv.test(Platform.environment);
-      }
-    } catch (_) {
-      dotenv.test(Platform.environment);
+    if (await File(fileName).exists()) {
+      await dotenv.load(fileName: fileName);
     }
   }
 
   static String get(String key, {String defaultValue = ''}) {
-    return dotenv.env[key] ?? defaultValue;
+    return dotenv.env[key] ?? Platform.environment[key] ?? defaultValue;
   }
 }


### PR DESCRIPTION
## Summary
- remove uses of outdated `dotenv.test` API
- fallback to platform environment variables in AppConfig

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685935982de4832f8852106820430b78