### PR TITLE
Add Android release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,19 @@ flutter analyze
 - Lógica de negócio
 - Widgets principais
 
+## 📦 Publicação para Android
+
+1. Gere um keystore para assinar o aplicativo:
+   ```bash
+   keytool -genkey -v -keystore keystore.jks -alias upload -keyalg RSA -keysize 2048 -validity 10000
+   ```
+2. Copie `android/key.properties.example` para `android/key.properties` e informe as senhas e o caminho do keystore.
+3. Crie o pacote de lançamento:
+   ```bash
+   flutter build appbundle --release
+   ```
+4. Envie o arquivo `.aab` de `build/app/outputs/bundle/release/` para a Google Play Console.
+
 ## 📱 Capturas de Tela
 
 *As capturas de tela serão adicionadas após a implementação completa da UI*

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,6 +25,12 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     namespace "com.precinho.precinho_app"
     compileSdkVersion flutter.compileSdkVersion
@@ -54,11 +60,20 @@ android {
         versionName flutterVersionName
     }
 
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig keystorePropertiesFile.exists() ? signingConfigs.release : signingConfigs.debug
         }
     }
 }

--- a/android/key.properties.example
+++ b/android/key.properties.example
@@ -1,0 +1,5 @@
+# Example signing configuration for release builds
+storePassword=YOUR_STORE_PASSWORD
+keyPassword=YOUR_KEY_PASSWORD
+keyAlias=upload
+storeFile=../keystore.jks


### PR DESCRIPTION
## Summary
- add example signing config for Android
- document steps to build release version
- configure build.gradle to use key.properties for release signing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8e0087fc832fa0c8b7f0a740349b