### PR TITLE
Update Gradle for Java 21

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.22'
     repositories {
         google()
         mavenCentral()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,7 +23,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version "8.3.0" apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     // END: FlutterFire Configuration


### PR DESCRIPTION
## Summary
- update Gradle wrapper to 8.4
- bump Android plugin to 8.3.0
- update Kotlin plugin version to 1.9.22

These updates allow building the Android release with JDK 21.

## Testing
- `flutter pub get` *(fails: `bash: flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a9be50a10832fbdc7db16681dbcec