### PR TITLE
Add price photo & invoice QR contribution features

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -26,6 +26,8 @@ class AppConstants {
   static const int pointsForStoreSubmission = 15;
   static const int pointsForProductSubmission = 5;
   static const int pointsForReview = 2;
+  static const int pointsForPricePhoto = 8;
+  static const int pointsForInvoice = 12;
 
   // Contas de administrador
   static const List<String> adminEmails = [

--- a/lib/core/constants/enums.dart
+++ b/lib/core/constants/enums.dart
@@ -133,3 +133,12 @@ enum ErrorType {
   final String displayName;
 }
 
+enum ContributionType {
+  pricePhoto('price_photo', 'Foto de Preço'),
+  invoice('invoice', 'Nota Fiscal');
+
+  const ContributionType(this.value, this.displayName);
+  final String value;
+  final String displayName;
+}
+

--- a/lib/data/datasources/contribution_service.dart
+++ b/lib/data/datasources/contribution_service.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:geolocator/geolocator.dart';
+
+import '../../core/constants/app_constants.dart';
+import '../../core/constants/enums.dart';
+import '../../core/logging/firebase_logger.dart';
+
+class ContributionService {
+  final FirebaseFirestore _firestore;
+  final FirebaseStorage _storage;
+
+  ContributionService({
+    FirebaseFirestore? firestore,
+    FirebaseStorage? storage,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _storage = storage ?? FirebaseStorage.instance;
+
+  Future<void> submitPricePhoto({
+    required File image,
+    required Position position,
+    required String userId,
+  }) async {
+    final path = 'price_photos/${DateTime.now().millisecondsSinceEpoch}.jpg';
+    final ref = _storage.ref().child(path);
+    await ref.putFile(image);
+    final url = await ref.getDownloadURL();
+    final data = {
+      'type': ContributionType.pricePhoto.value,
+      'user_id': userId,
+      'image_url': url,
+      'latitude': position.latitude,
+      'longitude': position.longitude,
+      'created_at': Timestamp.now(),
+      'status': ModerationStatus.pending.value,
+      'points': AppConstants.pointsForPricePhoto,
+    };
+    FirebaseLogger.log('submitPricePhoto', data);
+    await _firestore.collection('contributions').add(data);
+  }
+
+  Future<void> submitInvoice({
+    required File image,
+    required String qrLink,
+    required String userId,
+  }) async {
+    final path = 'invoices/${DateTime.now().millisecondsSinceEpoch}.jpg';
+    final ref = _storage.ref().child(path);
+    await ref.putFile(image);
+    final url = await ref.getDownloadURL();
+    final data = {
+      'type': ContributionType.invoice.value,
+      'user_id': userId,
+      'image_url': url,
+      'qr_link': qrLink,
+      'created_at': Timestamp.now(),
+      'status': ModerationStatus.pending.value,
+      'points': AppConstants.pointsForInvoice,
+    };
+    FirebaseLogger.log('submitInvoice', data);
+    await _firestore.collection('contributions').add(data);
+  }
+}

--- a/lib/presentation/pages/feed/feed_page.dart
+++ b/lib/presentation/pages/feed/feed_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
 import '../price/price_detail_page.dart';
+import '../price/price_photo_page.dart';
+import '../invoice/invoice_qr_page.dart';
 
 class FeedPage extends StatefulWidget {
   const FeedPage({super.key});
@@ -114,6 +116,26 @@ class _FeedPageState extends State<FeedPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('In\u00edcio'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.camera_alt),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const PricePhotoPage()),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.qr_code),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const InvoiceQrPage()),
+              );
+            },
+          ),
+        ],
       ),
       body: _docs.isEmpty && _isLoading
           ? const Center(child: CircularProgressIndicator())

--- a/lib/presentation/pages/invoice/invoice_qr_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_page.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/constants/app_constants.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/logging/firebase_logger.dart';
+import '../../providers/auth_provider.dart';
+import '../../../data/datasources/contribution_service.dart';
+
+class InvoiceQrPage extends ConsumerStatefulWidget {
+  const InvoiceQrPage({super.key});
+
+  @override
+  ConsumerState<InvoiceQrPage> createState() => _InvoiceQrPageState();
+}
+
+class _InvoiceQrPageState extends ConsumerState<InvoiceQrPage> {
+  final _picker = ImagePicker();
+  File? _image;
+  String? _qrLink;
+
+  Future<void> _pickImage(ImageSource source) async {
+    final picked = await _picker.pickImage(source: source, imageQuality: AppConstants.imageQuality);
+    if (picked == null) return;
+    if (source == ImageSource.camera) {
+      _image = File(picked.path);
+      await _scanQr(File(picked.path));
+    } else {
+      _image = File(picked.path);
+      await _scanQr(File(picked.path));
+    }
+    setState(() {});
+  }
+
+  Future<void> _scanQr(File file) async {
+    final scanner = MobileScannerController();
+    try {
+      final result = await scanner.analyzeImage(file.path);
+      if (result.barcodes.isNotEmpty) {
+        _qrLink = result.barcodes.first.rawValue;
+      }
+    } catch (e) {
+      FirebaseLogger.log('qr_scan_error', {'error': e.toString()});
+    } finally {
+      scanner.dispose();
+    }
+  }
+
+  Future<void> _submit() async {
+    final user = ref.read(currentUserProvider);
+    if (_image == null || _qrLink == null || user == null) return;
+    try {
+      await ContributionService().submitInvoice(
+        image: _image!,
+        qrLink: _qrLink!,
+        userId: user.id,
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Enviado para análise')));
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      FirebaseLogger.log('submitInvoice_error', {'error': e.toString()});
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Erro: $e')));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('QR Code NF')),
+      body: Padding(
+        padding: const EdgeInsets.all(AppTheme.paddingLarge),
+        child: Column(
+          children: [
+            if (_image != null)
+              Image.file(_image!, height: 200),
+            const SizedBox(height: AppTheme.paddingMedium),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                ElevatedButton.icon(
+                  onPressed: () => _pickImage(ImageSource.camera),
+                  icon: const Icon(Icons.qr_code_scanner),
+                  label: const Text('Escanear'),
+                ),
+                ElevatedButton.icon(
+                  onPressed: () => _pickImage(ImageSource.gallery),
+                  icon: const Icon(Icons.photo),
+                  label: const Text('Galeria'),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppTheme.paddingLarge),
+            ElevatedButton(
+              onPressed: _image != null && _qrLink != null ? _submit : null,
+              child: const Text('Enviar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/price/price_photo_page.dart
+++ b/lib/presentation/pages/price/price_photo_page.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:exif/exif.dart';
+import 'package:flutter/material.dart';
+import 'package:image/image.dart' as img;
+import 'package:image_picker/image_picker.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/constants/app_constants.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/logging/firebase_logger.dart';
+import '../../providers/auth_provider.dart';
+import '../../../data/datasources/contribution_service.dart';
+
+class PricePhotoPage extends ConsumerStatefulWidget {
+  const PricePhotoPage({super.key});
+
+  @override
+  ConsumerState<PricePhotoPage> createState() => _PricePhotoPageState();
+}
+
+class _PricePhotoPageState extends ConsumerState<PricePhotoPage> {
+  final _picker = ImagePicker();
+  File? _image;
+  Position? _position;
+
+  Future<void> _pickImage(ImageSource source) async {
+    final picked = await _picker.pickImage(source: source, imageQuality: AppConstants.imageQuality);
+    if (picked == null) return;
+
+    if (source == ImageSource.gallery) {
+      final bytes = await picked.readAsBytes();
+      final tags = await readExifFromBytes(bytes);
+      if (!tags.containsKey('GPS GPSLatitude') || !tags.containsKey('GPS GPSLongitude')) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Imagem sem geolocalização')));
+        }
+        return;
+      }
+      final latValues = tags['GPS GPSLatitude']!.values;
+      final lonValues = tags['GPS GPSLongitude']!.values;
+      double _convert(List values) {
+        final d = values[0].toDouble();
+        final m = values[1].toDouble();
+        final s = values[2].toDouble();
+        return d + m / 60 + s / 3600;
+      }
+      final lat = _convert(latValues);
+      final lon = _convert(lonValues);
+      _position = Position(latitude: lat, longitude: lon, timestamp: DateTime.now(), accuracy: 0, altitude: 0, heading: 0, speed: 0, speedAccuracy: 0);
+    } else {
+      final permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied || permission == LocationPermission.deniedForever) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Permissão de localização negada')));
+        }
+        return;
+      }
+      _position = await Geolocator.getCurrentPosition();
+    }
+
+    setState(() {
+      _image = File(picked.path);
+    });
+  }
+
+  bool _validateImage(File file) {
+    final bytes = file.readAsBytesSync();
+    final image = img.decodeImage(bytes);
+    if (image == null) return false;
+    int sum = 0;
+    for (final p in image.getBytes()) {
+      sum += p;
+    }
+    final avg = sum / image.length;
+    return avg > 20; // evita imagem muito escura
+  }
+
+  Future<void> _submit() async {
+    final user = ref.read(currentUserProvider);
+    if (_image == null || _position == null || user == null) return;
+    if (!_validateImage(_image!)) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Imagem de baixa qualidade')));
+      }
+      return;
+    }
+    try {
+      await ContributionService().submitPricePhoto(
+        image: _image!,
+        position: _position!,
+        userId: user.id,
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Enviado para análise')));
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      FirebaseLogger.log('submitPricePhoto_error', {'error': e.toString()});
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Erro: $e')));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Foto de Preço'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(AppTheme.paddingLarge),
+        child: Column(
+          children: [
+            if (_image != null)
+              Image.file(_image!, height: 200),
+            const SizedBox(height: AppTheme.paddingMedium),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                ElevatedButton.icon(
+                  onPressed: () => _pickImage(ImageSource.camera),
+                  icon: const Icon(Icons.camera_alt),
+                  label: const Text('Câmera'),
+                ),
+                ElevatedButton.icon(
+                  onPressed: () => _pickImage(ImageSource.gallery),
+                  icon: const Icon(Icons.photo),
+                  label: const Text('Galeria'),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppTheme.paddingLarge),
+            ElevatedButton(
+              onPressed: _image != null && _position != null ? _submit : null,
+              child: const Text('Enviar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,9 @@ dependencies:
   # geocoding: ^2.1.1
   # camera: ^0.10.5+5
   image_picker: ^1.0.4
+  exif: ^3.1.1
+  image: ^4.1.3
+  mobile_scanner: ^3.5.0
   # google_maps_flutter: ^2.5.0
   # google_mlkit_text_recognition: ^0.10.0
   # permission_handler: ^11.1.0

--- a/test/contribution_service_test.dart
+++ b/test/contribution_service_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:precinho_app/data/datasources/contribution_service.dart';
+
+void main() {
+  test('service can be instantiated', () {
+    final service = ContributionService();
+    expect(service, isNotNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add dependencies for photo metadata and QR scanning
- define contribution enum and scoring constants
- create service to submit photo and invoice contributions
- implement price photo capture page
- implement invoice QR code capture page
- expose new actions in feed page
- add minimal test

## Testing
- `dart format lib` *(fails: `dart: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685aa55df76c832fa1540fd770227254