### PR TITLE
Fix QR code scan for mobile_scanner 3.5

### DIFF
--- a/lib/presentation/pages/invoice/invoice_qr_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_page.dart
@@ -40,9 +40,11 @@ class _InvoiceQrPageState extends ConsumerState<InvoiceQrPage> {
     final scanner = MobileScannerController();
     try {
       final bool success = await scanner.analyzeImage(file.path);
-      if (success &&
-          scanner.barcodes.value.barcodes.isNotEmpty) {
-        _qrLink = scanner.barcodes.value.barcodes.first.rawValue;
+      if (success) {
+        final capture = await scanner.barcodes.first;
+        if (capture.barcodes.isNotEmpty) {
+          _qrLink = capture.barcodes.first.rawValue;
+        }
       }
     } catch (e) {
       FirebaseLogger.log('qr_scan_error', {'error': e.toString()});


### PR DESCRIPTION
## Summary
- fix `_scanQr` to wait for the first value from `scanner.barcodes`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b633e0af0832f9841f0c183922198