### PR TITLE
Fix dotenv not initialized error

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -9,6 +9,9 @@ class AppConfig {
   }
 
   static String get(String key, {String defaultValue = ''}) {
-    return dotenv.env[key] ?? Platform.environment[key] ?? defaultValue;
+    if (dotenv.isInitialized && dotenv.env.containsKey(key)) {
+      return dotenv.env[key]!;
+    }
+    return Platform.environment[key] ?? defaultValue;
   }
 }


### PR DESCRIPTION
## Summary
- avoid NotInitializedError when reading env vars without a `.env` file

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6bf3ab44832fb5ee4231090ad138