### PR TITLE
Fix Firebase duplicate app error

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,9 +16,11 @@ void main() async {
 
   await AppConfig.load();
 
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  }
 
   runApp(
     const ProviderScope(


### PR DESCRIPTION
## Summary
- avoid initializing Firebase more than once

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c68fb581c832f879974229adeab26