### PR TITLE
Fix login layout overflow

### DIFF
--- a/lib/presentation/pages/auth/login_page.dart
+++ b/lib/presentation/pages/auth/login_page.dart
@@ -189,8 +189,9 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                         const SizedBox(height: AppTheme.paddingLarge),
 
                         // Link para cadastro
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
+                        Wrap(
+                          alignment: WrapAlignment.center,
+                          crossAxisAlignment: WrapCrossAlignment.center,
                           children: [
                             Text(
                               'Não tem uma conta? ',


### PR DESCRIPTION
## Summary
- avoid overflow in login page by using a `Wrap` widget for the registration link

## Testing
- `dart format lib/presentation/pages/auth/login_page.dart` *(fails: command not found)*
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cb26da09c832fbf35860d4ce4b137