### PR TITLE
Update stats to show invoices

### DIFF
--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -153,9 +153,9 @@ class ProfilePage extends ConsumerWidget {
                 Expanded(
                   child: _buildStatItem(
                     context,
-                    'Listas Criadas',
+                    'Notas Fiscais Enviadas',
                     '8', // Placeholder
-                    Icons.list,
+                    Icons.receipt,
                   ),
                 ),
               ],


### PR DESCRIPTION
## Summary
- adjust the stats section on profile page to show *Notas Fiscais Enviadas* with a receipt icon

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter test integration_test/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d375e8a50832fbbead42104194b21