### PR TITLE
Refactor shopping list storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ flutter run
 ### Configuração do Firebase
 
 1. **Firestore Database:**
-   - Crie as coleções: `users`, `products`, `stores`, `prices`, `shopping_lists`
+   - Crie as coleções: `users`, `products`, `stores`, `prices`
+   - As listas de compras agora são armazenadas apenas no dispositivo e não
+     precisam de coleção em banco de dados
    - Configure as regras de segurança
    - Crie os índices compostos definidos em `firestore.indexes.json`
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,14 +15,6 @@
         {"fieldPath": "store_id", "order": "ASCENDING"},
         {"fieldPath": "created_at", "order": "DESCENDING"}
       ]
-    },
-    {
-      "collectionGroup": "shopping_lists",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {"fieldPath": "user_id", "order": "ASCENDING"},
-        {"fieldPath": "created_at", "order": "DESCENDING"}
-      ]
     }
   ],
   "fieldOverrides": []

--- a/lib/data/datasources/shopping_list_storage.dart
+++ b/lib/data/datasources/shopping_list_storage.dart
@@ -1,34 +1,33 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:convert';
+
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/shopping_list_model.dart';
 
 class ShoppingListStorage {
-  final _firestore = FirebaseFirestore.instance;
-  final _auth = FirebaseAuth.instance;
+  static const _keyPrefix = 'shopping_lists_';
+
+  String _key() {
+    final uid = FirebaseAuth.instance.currentUser?.uid ?? 'local';
+    return '${_keyPrefix}$uid';
+  }
 
   Future<List<ShoppingListModel>> loadLists() async {
-    final uid = _auth.currentUser?.uid;
-    if (uid == null) return [];
-    final snap = await _firestore
-        .collection('shopping_lists')
-        .where('user_id', isEqualTo: uid)
-        .get();
-    return snap.docs
-        .map((e) =>
-            ShoppingListModel.fromJson({...e.data(), 'id': e.id}))
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(_key());
+    if (data == null) return [];
+    final decoded = jsonDecode(data) as List<dynamic>;
+    return decoded
+        .map((e) => ShoppingListModel.fromJson(
+            Map<String, dynamic>.from(e as Map)))
         .toList();
   }
 
   Future<void> saveLists(List<ShoppingListModel> lists) async {
-    final uid = _auth.currentUser?.uid;
-    if (uid == null) return;
-    final batch = _firestore.batch();
-    final collection = _firestore.collection('shopping_lists');
-    for (final list in lists) {
-      final doc = collection.doc(list.id);
-      batch.set(doc, list.toJson());
-    }
-    await batch.commit();
+    final prefs = await SharedPreferences.getInstance();
+    final data = jsonEncode(lists.map((e) => e.toJson()).toList());
+    await prefs.setString(_key(), data);
   }
 }
+


### PR DESCRIPTION
## Summary
- store shopping lists in local shared preferences instead of Firestore
- update Firebase setup docs to mention local lists
- remove shopping_lists index from Firestore config

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d515a7400832f92b0dcbb91acc5ff