### PR TITLE
Fix RenderFlex overflow in store list

### DIFF
--- a/lib/presentation/pages/store/store_search_page.dart
+++ b/lib/presentation/pages/store/store_search_page.dart
@@ -130,6 +130,7 @@ class _StoreSearchPageState extends ConsumerState<StoreSearchPage> {
                     final distance = item['distance'] as double?;
                     return Card(
                       child: ListTile(
+                        isThreeLine: true,
                         leading: const Icon(
                           Icons.store,
                           color: AppTheme.primaryColor,


### PR DESCRIPTION
## Summary
- fix RenderFlex overflow on store search list by enabling three line tile

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5b401c30832fbc6e5ca8e47589b8