### PR TITLE
Add invoice scanning interface

### DIFF
--- a/lib/data/datasources/invoice_service.dart
+++ b/lib/data/datasources/invoice_service.dart
@@ -1,0 +1,53 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../core/constants/enums.dart';
+import '../../core/logging/firebase_logger.dart';
+
+class InvoiceService {
+  final FirebaseFirestore _firestore;
+
+  InvoiceService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  Future<void> submitInvoice({
+    required String qrLink,
+    required String accessKey,
+    required String cnpj,
+    required String series,
+    required String number,
+    required String userId,
+  }) async {
+    final existing = await _firestore
+        .collection('invoices')
+        .where('access_key', isEqualTo: accessKey)
+        .limit(1)
+        .get();
+    if (existing.docs.isNotEmpty) {
+      throw Exception('Nota fiscal j\u00e1 cadastrada');
+    }
+
+    final data = {
+      'user_id': userId,
+      'qr_link': qrLink,
+      'access_key': accessKey,
+      'cnpj': cnpj,
+      'series': series,
+      'number': number,
+      'created_at': Timestamp.now(),
+      'status': ModerationStatus.underReview.value,
+    };
+    FirebaseLogger.log('submitInvoice', data);
+    await _firestore.collection('invoices').add(data);
+  }
+
+  Stream<QuerySnapshot> userInvoices(String userId) {
+    return _firestore
+        .collection('invoices')
+        .where('user_id', isEqualTo: userId)
+        .orderBy('created_at', descending: true)
+        .snapshots();
+  }
+
+  Stream<DocumentSnapshot> invoiceById(String id) {
+    return _firestore.collection('invoices').doc(id).snapshots();
+  }
+}

--- a/lib/presentation/pages/invoice/invoice_detail_page.dart
+++ b/lib/presentation/pages/invoice/invoice_detail_page.dart
@@ -1,0 +1,74 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../../../core/constants/enums.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/utils/formatters.dart';
+
+class InvoiceDetailPage extends StatelessWidget {
+  final String invoiceId;
+  const InvoiceDetailPage({required this.invoiceId, super.key});
+
+  Stream<DocumentSnapshot> _invoiceStream() {
+    return FirebaseFirestore.instance
+        .collection('invoices')
+        .doc(invoiceId)
+        .snapshots();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Nota Fiscal')),
+      body: StreamBuilder<DocumentSnapshot>(
+        stream: _invoiceStream(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (!snapshot.hasData || !snapshot.data!.exists) {
+            return const Center(child: Text('Nota fiscal n\u00e3o encontrada'));
+          }
+          final data = snapshot.data!.data() as Map<String, dynamic>;
+          final date = (data['created_at'] as Timestamp?)?.toDate();
+          final status = ModerationStatus.values.firstWhere(
+            (s) => s.value == data['status'],
+            orElse: () => ModerationStatus.underReview,
+          );
+          final products = (data['products'] as List?)?.cast<String>() ?? [];
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(AppTheme.paddingLarge),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Link: ${data['qr_link'] ?? ''}'),
+                const SizedBox(height: AppTheme.paddingMedium),
+                Text('CNPJ: ${data['cnpj']}'),
+                Text('S\u00e9rie: ${data['series']}'),
+                Text('N\u00famero: ${data['number']}'),
+                if (date != null)
+                  Text('Enviada em: ${Formatters.formatDateTime(date)}'),
+                const SizedBox(height: AppTheme.paddingMedium),
+                Text('Status: ${status.displayName}'),
+                if (status == ModerationStatus.approved && products.isNotEmpty) ...[
+                  const SizedBox(height: AppTheme.paddingLarge),
+                  Text(
+                    'Produtos',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: AppTheme.paddingSmall),
+                  for (final p in products)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: AppTheme.paddingSmall),
+                      child: Text(p),
+                    ),
+                ]
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/invoice/invoice_qr_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_page.dart
@@ -5,7 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/logging/firebase_logger.dart';
 import '../../providers/auth_provider.dart';
-import '../../../data/datasources/contribution_service.dart';
+import '../../../data/datasources/invoice_service.dart';
+import 'invoices_page.dart';
 
 class InvoiceQrPage extends ConsumerStatefulWidget {
   const InvoiceQrPage({super.key});
@@ -17,7 +18,10 @@ class InvoiceQrPage extends ConsumerStatefulWidget {
 class _InvoiceQrPageState extends ConsumerState<InvoiceQrPage> {
   final MobileScannerController _controller = MobileScannerController();
   String? _qrLink;
+  String? _accessKey;
+  bool _flashOn = false;
   bool _isProcessing = false;
+  String? _message;
 
   String? _extractAccessKey(String data) {
     final match = RegExp(r'(\d{44})').firstMatch(data);
@@ -48,18 +52,16 @@ class _InvoiceQrPageState extends ConsumerState<InvoiceQrPage> {
     if (value == null) return;
     final key = _extractAccessKey(value);
     if (key == null) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('QR Code n\u00e3o \u00e9 uma Nota Fiscal')),
-        );
-      }
+      setState(() {
+        _message = 'QR Code n\u00e3o \u00e9 de uma Nota Fiscal V\u00e1lida';
+      });
       return;
     }
     setState(() {
       _qrLink = value;
-      _isProcessing = true;
+      _accessKey = key;
+      _message = 'QR Code lido com sucesso';
     });
-    await _submit(key);
   }
 
   @override
@@ -72,18 +74,25 @@ class _InvoiceQrPageState extends ConsumerState<InvoiceQrPage> {
     final user = ref.read(currentUserProvider);
     if (_qrLink == null || user == null) return;
     final cnpj = key.substring(6, 20);
+    final series = key.substring(22, 25);
+    final number = key.substring(25, 34);
     try {
-      await ContributionService().submitInvoice(
+      await InvoiceService().submitInvoice(
         qrLink: _qrLink!,
         accessKey: key,
         cnpj: cnpj,
+        series: series,
+        number: number,
         userId: user.id,
       );
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Nota fiscal cadastrada com sucesso')),
         );
-        Navigator.pop(context);
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (_) => const InvoicesPage()),
+        );
       }
     } catch (e) {
       FirebaseLogger.log('submitInvoice_error', {'error': e.toString()});
@@ -98,27 +107,84 @@ class _InvoiceQrPageState extends ConsumerState<InvoiceQrPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('QR Code NF')),
-      body: Padding(
-        padding: const EdgeInsets.all(AppTheme.paddingLarge),
-        child: Column(
-          children: [
-            Expanded(
-              child: MobileScanner(
-                controller: _controller,
-                onDetect: _onDetect,
+      appBar: AppBar(
+        title: const Text('Escanear Nota Fiscal'),
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+        actions: [
+          IconButton(
+            icon: Icon(_flashOn ? Icons.flash_on : Icons.flash_off),
+            onPressed: () {
+              _controller.toggleTorch();
+              setState(() => _flashOn = !_flashOn);
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.cameraswitch),
+            onPressed: _controller.switchCamera,
+          ),
+        ],
+      ),
+      body: Stack(
+        children: [
+          MobileScanner(
+            controller: _controller,
+            onDetect: _onDetect,
+          ),
+          Center(
+            child: Container(
+              width: 250,
+              height: 250,
+              decoration: BoxDecoration(
+                border: Border.all(color: Colors.white, width: 2),
               ),
             ),
-            if (_qrLink != null)
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: AppTheme.paddingMedium),
-                child: Text(_qrLink!),
+          ),
+          Positioned(
+            bottom: 160,
+            left: 0,
+            right: 0,
+            child: Text(
+              _message ?? 'Aponte para o QR Code da nota fiscal',
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Colors.white),
+            ),
+          ),
+          if (_qrLink != null)
+            Positioned(
+              bottom: 120,
+              left: 0,
+              right: 0,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  _qrLink!,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(color: Colors.white),
+                ),
               ),
-            const SizedBox(height: AppTheme.paddingLarge),
-            if (_isProcessing)
-              const CircularProgressIndicator(),
-          ],
-        ),
+            ),
+          Positioned(
+            bottom: 20,
+            left: 0,
+            right: 0,
+            child: Column(
+              children: [
+                if (_isProcessing)
+                  const CircularProgressIndicator()
+                else
+                  ElevatedButton(
+                    onPressed: _qrLink != null && _accessKey != null
+                        ? () => _submit(_accessKey!)
+                        : null,
+                    child: const Text('Enviar Nota Fiscal'),
+                  ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/presentation/pages/invoice/invoices_page.dart
+++ b/lib/presentation/pages/invoice/invoices_page.dart
@@ -1,0 +1,74 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/constants/enums.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/utils/formatters.dart';
+import '../../providers/auth_provider.dart';
+import 'invoice_detail_page.dart';
+
+class InvoicesPage extends ConsumerWidget {
+  const InvoicesPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final user = ref.watch(currentUserProvider);
+    if (user == null) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notas Fiscais')),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('invoices')
+            .where('user_id', isEqualTo: user.id)
+            .orderBy('created_at', descending: true)
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('Nenhuma nota fiscal enviada'));
+          }
+          return ListView.builder(
+            itemCount: docs.length,
+            padding: const EdgeInsets.all(AppTheme.paddingMedium),
+            itemBuilder: (context, index) {
+              final doc = docs[index];
+              final data = doc.data() as Map<String, dynamic>;
+              final date = (data['created_at'] as Timestamp?)?.toDate();
+              final status = ModerationStatus.values.firstWhere(
+                (s) => s.value == data['status'],
+                orElse: () => ModerationStatus.underReview,
+              );
+              return Card(
+                child: ListTile(
+                  title: Text('Série ${data['series']} - Nº ${data['number']}'),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (date != null)
+                        Text(Formatters.formatDateTime(date)),
+                      Text(status.displayName),
+                    ],
+                  ),
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => InvoiceDetailPage(invoiceId: doc.id),
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `InvoiceService` for Firestore invoice storage
- enhance QR scanner interface with flash/camera controls and feedback
- add pages to list sent invoices and view invoice details

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfc69e984832f8d20384c6ef0acc6