### PR TITLE
Fix contributions imports and list id type

### DIFF
--- a/lib/presentation/pages/feed/feed_page.dart
+++ b/lib/presentation/pages/feed/feed_page.dart
@@ -287,7 +287,7 @@ class _FeedPageState extends ConsumerState<FeedPage> {
 
     if (result != true || selectedId == null) return;
 
-    var listId = selectedId;
+    String listId = selectedId!;
     if (lists.isEmpty) {
       listId = ref.read(shoppingListProvider.notifier).createList(selectedId!);
     }

--- a/lib/presentation/pages/profile/contributions_page.dart
+++ b/lib/presentation/pages/profile/contributions_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
 import '../../providers/auth_provider.dart';
+import '../../../core/constants/enums.dart';
 
 class ContributionsPage extends ConsumerStatefulWidget {
   const ContributionsPage({super.key});


### PR DESCRIPTION
## Summary
- import enums in contributions page
- ensure listId isn't nullable when adding items from feed

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e751b2dd8832fa70c608350a82616