### PR TITLE
Fix list tile overflow

### DIFF
--- a/lib/presentation/pages/store/store_search_page.dart
+++ b/lib/presentation/pages/store/store_search_page.dart
@@ -130,6 +130,10 @@ class _StoreSearchPageState extends ConsumerState<StoreSearchPage> {
                     final distance = item['distance'] as double?;
                     return Card(
                       child: ListTile(
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 8,
+                        ),
                         isThreeLine: true,
                         leading: const Icon(
                           Icons.store,


### PR DESCRIPTION
## Summary
- fix RenderFlex overflow in store search page by increasing vertical padding for each list tile

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f192804a4832f963a8a04508f2e70