### PR TITLE
Fix unmatched bracket in StorePricesPage

### DIFF
--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -265,9 +265,10 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                   },
                 ),
               ),
+            ],
           );
         },
-            ),
+      ),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- fix column widget closing bracket to properly terminate the children list

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f42caf0d0832f80ac7926d11987bd