### PR TITLE
Fix navigation in invoice QR pages

### DIFF
--- a/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
@@ -137,11 +137,13 @@ class _InvoiceQrConfirmPageState extends ConsumerState<InvoiceQrConfirmPage> {
                     textAlign: TextAlign.center,
                   ),
                   const SizedBox(height: AppTheme.paddingLarge),
-                  ElevatedButton(
-                    onPressed: _isValid ? _submit : () => Navigator.pop(context),
-                    child: Text(_isValid ? 'Enviar Nota Fiscal' : 'OK'),
-                  ),
-                  const SizedBox(height: AppTheme.paddingMedium),
+                  if (_isValid) ...[
+                    ElevatedButton(
+                      onPressed: _submit,
+                      child: const Text('Enviar Nota Fiscal'),
+                    ),
+                    const SizedBox(height: AppTheme.paddingMedium),
+                  ],
                   OutlinedButton(
                     onPressed: () {
                       Navigator.pushReplacement(

--- a/lib/presentation/pages/invoice/invoice_qr_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_page.dart
@@ -3,6 +3,7 @@ import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/themes/app_theme.dart';
+import '../home/home_page.dart';
 import 'invoice_qr_confirm_page.dart';
 
 class InvoiceQrPage extends ConsumerStatefulWidget {
@@ -50,7 +51,13 @@ class _InvoiceQrPageState extends ConsumerState<InvoiceQrPage> {
         title: const Text('Escanear Nota Fiscal'),
         leading: IconButton(
           icon: const Icon(Icons.close),
-          onPressed: () => Navigator.pop(context),
+          onPressed: () {
+            Navigator.pushAndRemoveUntil(
+              context,
+              MaterialPageRoute(builder: (_) => const HomePage()),
+              (route) => false,
+            );
+          },
         ),
         actions: [
           IconButton(


### PR DESCRIPTION
## Summary
- update invoice QR scan page to send users back to Home when closing
- remove redundant `OK` button from QR confirmation when invalid

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686110abee1c832f9bd94203d07b1e96