### PR TITLE
Fix navigation when QR capture fails

### DIFF
--- a/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
@@ -6,6 +6,7 @@ import '../../../core/themes/app_theme.dart';
 import '../../providers/auth_provider.dart';
 import '../../../data/datasources/invoice_service.dart';
 import 'invoice_qr_page.dart';
+import '../home/home_page.dart';
 import 'invoices_page.dart';
 
 class InvoiceQrConfirmPage extends ConsumerStatefulWidget {
@@ -146,15 +147,33 @@ class _InvoiceQrConfirmPageState extends ConsumerState<InvoiceQrConfirmPage> {
                   ],
                   OutlinedButton(
                     onPressed: () {
-                      Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(builder: (_) => const InvoiceQrPage()),
-                      );
+                      if (_isValid) {
+                        Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(builder: (_) => const InvoiceQrPage()),
+                        );
+                      } else {
+                        Navigator.pushAndRemoveUntil(
+                          context,
+                          MaterialPageRoute(builder: (_) => const HomePage()),
+                          (route) => route.isFirst,
+                        );
+                      }
                     },
                     child: const Text('Ler novo QR Code'),
                   ),
                   TextButton(
-                    onPressed: () => Navigator.pop(context),
+                    onPressed: () {
+                      if (_isValid) {
+                        Navigator.pop(context);
+                      } else {
+                        Navigator.pushAndRemoveUntil(
+                          context,
+                          MaterialPageRoute(builder: (_) => const HomePage()),
+                          (route) => route.isFirst,
+                        );
+                      }
+                    },
                     child: const Text('Voltar'),
                   ),
                 ],


### PR DESCRIPTION
## Summary
- show home page when invalid QR is scanned
- align "Ler novo QR Code" with back behavior on error

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615ac05324832fac65a17ef853799c