### PR TITLE
Fix element alignment after QR code scan

### DIFF
--- a/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
@@ -123,9 +123,10 @@ class _InvoiceQrConfirmPageState extends ConsumerState<InvoiceQrConfirmPage> {
           ? const Center(child: CircularProgressIndicator())
           : Padding(
               padding: const EdgeInsets.all(AppTheme.paddingLarge),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
                   Icon(
                     _isValid ? Icons.receipt_long : Icons.error,
                     size: 96,


### PR DESCRIPTION
## Summary
- center the invoice QR confirmation content

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686162a5d7b4832fa45e79bf2450d1cb