### PR TITLE
Fix parenthesis mismatch in invoice page

### DIFF
--- a/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
@@ -180,6 +180,7 @@ class _InvoiceQrConfirmPageState extends ConsumerState<InvoiceQrConfirmPage> {
                 ],
               ),
             ),
+            ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- fix missing `)` in `InvoiceQrConfirmPage`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861744975cc832fa34dd6cf92df94cc