### PR TITLE
Fix QR code retry navigation

### DIFF
--- a/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
@@ -148,18 +148,10 @@ class _InvoiceQrConfirmPageState extends ConsumerState<InvoiceQrConfirmPage> {
                   ],
                   OutlinedButton(
                     onPressed: () {
-                      if (_isValid) {
-                        Navigator.pushReplacement(
-                          context,
-                          MaterialPageRoute(builder: (_) => const InvoiceQrPage()),
-                        );
-                      } else {
-                        Navigator.pushAndRemoveUntil(
-                          context,
-                          MaterialPageRoute(builder: (_) => const HomePage()),
-                          (route) => route.isFirst,
-                        );
-                      }
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(builder: (_) => const InvoiceQrPage()),
+                      );
                     },
                     child: const Text('Ler novo QR Code'),
                   ),


### PR DESCRIPTION
## Summary
- ensure that the 'Ler novo QR Code' button always opens the QR scan page so users can rescan when an error occurs

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862479836f8832fb72419a78131de77