### PR TITLE
Fix profile stats type mismatch

### DIFF
--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -18,9 +18,13 @@ Future<Map<String, int>> _fetchUserStats(String userId) async {
       .where('user_id', isEqualTo: userId)
       .count()
       .get();
+
+  final priceCount = priceAgg.count ?? 0;
+  final invoiceCount = invoiceAgg.count ?? 0;
+
   return {
-    'prices': priceAgg.count,
-    'invoices': invoiceAgg.count,
+    'prices': priceCount,
+    'invoices': invoiceCount,
   };
 }
 


### PR DESCRIPTION
## Summary
- avoid nullable `int` error in profile stats

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624eb94d9c832f88a35209ae98b17f