### PR TITLE
Add links to profile stats

### DIFF
--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -6,6 +6,8 @@ import '../../../core/utils/formatters.dart';
 import '../../providers/auth_provider.dart';
 import '../admin/admin_home_page.dart';
 import 'contributions_page.dart';
+import '../price/user_prices_page.dart';
+import '../invoice/invoices_page.dart';
 
 Future<Map<String, int>> _fetchUserStats(String userId) async {
   final priceAgg = await FirebaseFirestore.instance
@@ -175,6 +177,14 @@ class ProfilePage extends ConsumerWidget {
                         'Preços Cadastrados',
                         priceCount != null ? '$priceCount' : '...',
                         Icons.local_offer,
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const UserPricesPage(),
+                            ),
+                          );
+                        },
                       ),
                     ),
                     Expanded(
@@ -183,6 +193,14 @@ class ProfilePage extends ConsumerWidget {
                         'Notas Fiscais Enviadas',
                         invoiceCount != null ? '$invoiceCount' : '...',
                         Icons.receipt,
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const InvoicesPage(),
+                            ),
+                          );
+                        },
                       ),
                     ),
                   ],
@@ -195,8 +213,14 @@ class ProfilePage extends ConsumerWidget {
     );
   }
 
-  Widget _buildStatItem(BuildContext context, String label, String value, IconData icon) {
-    return Container(
+  Widget _buildStatItem(
+    BuildContext context,
+    String label,
+    String value,
+    IconData icon, {
+    VoidCallback? onTap,
+  }) {
+    final content = Container(
       padding: const EdgeInsets.all(AppTheme.paddingMedium),
       margin: const EdgeInsets.all(AppTheme.paddingSmall),
       decoration: BoxDecoration(
@@ -229,6 +253,11 @@ class ProfilePage extends ConsumerWidget {
         ],
       ),
     );
+
+    if (onTap != null) {
+      return InkWell(onTap: onTap, child: content);
+    }
+    return content;
   }
 
   Widget _buildMenuSection(BuildContext context, WidgetRef ref) {


### PR DESCRIPTION
## Summary
- add user prices and invoices imports
- make profile stats clickable so you can open user prices or invoices

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686266fefaf0832fb515c5b6c5acf1cd