### PR TITLE
Update price queries to use status

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ class Price {
   final DateTime createdAt;
   final DateTime? expiresAt;
   final bool isApproved;
+  final ModerationStatus status;
 }
 ```
 

--- a/lib/presentation/pages/feed/feed_page.dart
+++ b/lib/presentation/pages/feed/feed_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
+import '../../../core/constants/enums.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/shopping_list_provider.dart';
 import '../price/price_detail_page.dart';
@@ -115,7 +116,7 @@ class _FeedPageState extends ConsumerState<FeedPage> {
 
     Query query = FirebaseFirestore.instance
         .collection('prices')
-        .where('isApproved', isEqualTo: true)
+        .where('status', isEqualTo: ModerationStatus.approved.value)
         .orderBy('created_at', descending: true)
         .limit(20);
     if (_lastDoc != null) {

--- a/lib/presentation/pages/product/product_prices_page.dart
+++ b/lib/presentation/pages/product/product_prices_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
+import '../../../core/constants/enums.dart';
 import '../../providers/store_favorites_provider.dart';
 import '../price/add_price_page.dart';
 import '../price/price_detail_page.dart';
@@ -74,7 +75,8 @@ class _ProductPricesPageState extends ConsumerState<ProductPricesPage> {
               stream: FirebaseFirestore.instance
                   .collection('prices')
                   .where('product_id', isEqualTo: widget.product.id)
-                  .where('isApproved', isEqualTo: true)
+                  .where('status',
+                      isEqualTo: ModerationStatus.approved.value)
                   .orderBy('price')
                   .orderBy('created_at', descending: true)
                   .snapshots(),

--- a/lib/presentation/pages/shopping_list/shopping_list_detail_page.dart
+++ b/lib/presentation/pages/shopping_list/shopping_list_detail_page.dart
@@ -5,6 +5,7 @@ import 'package:geolocator/geolocator.dart';
 
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
+import '../../../core/constants/enums.dart';
 import '../../providers/shopping_list_provider.dart';
 import '../../providers/store_favorites_provider.dart';
 import '../product/product_search_page.dart';
@@ -102,7 +103,8 @@ class _ShoppingListDetailPageState extends ConsumerState<ShoppingListDetailPage>
               .collection('prices')
               .where('product_id', isEqualTo: item.productId)
               .where('store_id', isEqualTo: store.id)
-              .where('isApproved', isEqualTo: true)
+              .where('status',
+                  isEqualTo: ModerationStatus.approved.value)
               .orderBy('created_at', descending: true)
               .limit(1)
               .get();
@@ -160,7 +162,8 @@ class _ShoppingListDetailPageState extends ConsumerState<ShoppingListDetailPage>
             .collection('prices')
             .where('product_id', isEqualTo: item.productId)
             .where('store_id', isEqualTo: store.id)
-            .where('isApproved', isEqualTo: true)
+            .where('status',
+                isEqualTo: ModerationStatus.approved.value)
             .orderBy('created_at', descending: true)
             .limit(1)
             .get();

--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
+import '../../../core/constants/enums.dart';
 import '../../providers/store_favorites_provider.dart';
 import '../price/add_price_page.dart';
 import '../price/price_detail_page.dart';
@@ -106,7 +107,8 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
               stream: FirebaseFirestore.instance
                   .collection('prices')
                   .where('store_id', isEqualTo: widget.store.id)
-                  .where('isApproved', isEqualTo: true)
+                  .where('status',
+                      isEqualTo: ModerationStatus.approved.value)
                   .orderBy('price')
                   .orderBy('created_at', descending: true)
                   .snapshots(),


### PR DESCRIPTION
## Summary
- update README Price model documentation
- check status when querying `prices`

## Testing
- `dart format -o none README.md lib/presentation/pages/feed/feed_page.dart lib/presentation/pages/product/product_prices_page.dart lib/presentation/pages/store/store_prices_page.dart lib/presentation/pages/shopping_list/shopping_list_detail_page.dart` *(fails: `dart` not found)*
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626e3e8510832f9d31b5bdd6e44205