### PR TITLE
Add simple audio cue for QR and photo

### DIFF
--- a/lib/presentation/pages/invoice/invoice_qr_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 
 import '../../../core/themes/app_theme.dart';
 import '../home/home_page.dart';
@@ -22,6 +23,7 @@ class _InvoiceQrPageState extends ConsumerState<InvoiceQrPage> {
     if (capture.barcodes.isEmpty) return;
     final value = capture.barcodes.first.rawValue;
     if (value == null) return;
+    SystemSound.play(SystemSoundType.alert);
     _controller.stop();
     await Navigator.push(
       context,

--- a/lib/presentation/pages/price/price_photo_page.dart
+++ b/lib/presentation/pages/price/price_photo_page.dart
@@ -7,6 +7,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:camera/camera.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 
 import '../../../core/constants/app_constants.dart';
 import '../../../core/themes/app_theme.dart';
@@ -116,6 +117,7 @@ class _PricePhotoPageState extends ConsumerState<PricePhotoPage> {
       return;
     }
     final xFile = await _cameraController!.takePicture();
+    SystemSound.play(SystemSoundType.alert);
     _position = await Geolocator.getCurrentPosition();
     _image = File(xFile.path);
 


### PR DESCRIPTION
## Summary
- play a beep when a QR code is detected
- play a beep when a price photo is taken

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter test integration_test/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686276e982c4832fa86d7e96e167128d