### PR TITLE
Update user stats for price photo uploads

### DIFF
--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -12,6 +12,7 @@ Future<Map<String, int>> _fetchUserStats(String userId) async {
   final priceAgg = await FirebaseFirestore.instance
       .collection('prices')
       .where('user_id', isEqualTo: userId)
+      .where('image_url', isNull: false)
       .count()
       .get();
   final invoiceAgg = await FirebaseFirestore.instance
@@ -20,11 +21,11 @@ Future<Map<String, int>> _fetchUserStats(String userId) async {
       .count()
       .get();
 
-  final priceCount = priceAgg.count ?? 0;
+  final pricePhotoCount = priceAgg.count ?? 0;
   final invoiceCount = invoiceAgg.count ?? 0;
 
   return {
-    'prices': priceCount,
+    'prices': pricePhotoCount,
     'invoices': invoiceCount,
   };
 }
@@ -153,7 +154,7 @@ class ProfilePage extends ConsumerWidget {
     return FutureBuilder<Map<String, int>>(
       future: _fetchUserStats(user.id),
       builder: (context, snapshot) {
-        final priceCount = snapshot.data?['prices'];
+        final photoCount = snapshot.data?['prices'];
         final invoiceCount = snapshot.data?['invoices'];
 
         return Card(
@@ -173,8 +174,8 @@ class ProfilePage extends ConsumerWidget {
                     Expanded(
                       child: _buildStatItem(
                         context,
-                        'Preços Cadastrados',
-                        priceCount != null ? '$priceCount' : '...',
+                        'Fotos de Preços Enviadas',
+                        photoCount != null ? '$photoCount' : '...',
                         Icons.local_offer,
                         onTap: () {
                           Navigator.push(


### PR DESCRIPTION
## Summary
- adjust user stats to count only price entries with photos
- update stats label to display `Fotos de Preços Enviadas`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627f1b5b7c832f97f6a241ec43d1c9