### PR TITLE
Add HTML invoice import skeleton

### DIFF
--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -1,0 +1,83 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Serviço auxiliar para criação de entidades ao importar notas fiscais.
+class InvoiceImportService {
+  final FirebaseFirestore _firestore;
+
+  InvoiceImportService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  /// Cria ou retorna um comércio existente pelo CNPJ.
+  Future<DocumentReference<Map<String, dynamic>>> getOrCreateStore({
+    required String cnpj,
+    required String name,
+    String? address,
+  }) async {
+    final existing = await _firestore
+        .collection('stores')
+        .where('cnpj', isEqualTo: cnpj)
+        .limit(1)
+        .get();
+    if (existing.docs.isNotEmpty) {
+      return existing.docs.first.reference;
+    }
+
+    final data = {
+      'cnpj': cnpj,
+      'name': name,
+      if (address != null) 'address': address,
+      'created_at': Timestamp.now(),
+    };
+    final doc = await _firestore.collection('stores').add(data);
+    return doc;
+  }
+
+  /// Cria ou retorna um produto existente pelo EAN ou NCM.
+  Future<DocumentReference<Map<String, dynamic>>> getOrCreateProduct({
+    String? ean,
+    String? ncm,
+    required String name,
+  }) async {
+    Query<Map<String, dynamic>> query = _firestore.collection('products');
+    if (ean != null && ean.isNotEmpty) {
+      query = query.where('barcode', isEqualTo: ean);
+    } else if (ncm != null && ncm.isNotEmpty) {
+      query = query.where('ncm_code', isEqualTo: ncm);
+    }
+    final snap = await query.limit(1).get();
+    if (snap.docs.isNotEmpty) return snap.docs.first.reference;
+
+    final data = {
+      'name': name,
+      if (ean != null) 'barcode': ean,
+      if (ncm != null) 'ncm_code': ncm,
+      'created_at': Timestamp.now(),
+    };
+    final doc = await _firestore.collection('products').add(data);
+    return doc;
+  }
+
+  /// Cria um preço vinculado a um produto e comércio existentes.
+  Future<DocumentReference<Map<String, dynamic>>> createPrice({
+    String? ncm,
+    String? ean,
+    String? customCode,
+    required double value,
+    required String description,
+    required DocumentReference storeRef,
+    required DocumentReference productRef,
+  }) async {
+    final data = {
+      'product_id': productRef.id,
+      'store_id': storeRef.id,
+      'price': value,
+      'description': description,
+      if (ncm != null) 'ncm_code': ncm,
+      if (ean != null) 'ean_code': ean,
+      if (customCode != null) 'custom_code': customCode,
+      'created_at': Timestamp.now(),
+    };
+    final doc = await _firestore.collection('prices').add(data);
+    return doc;
+  }
+}

--- a/lib/presentation/pages/admin/admin_home_page.dart
+++ b/lib/presentation/pages/admin/admin_home_page.dart
@@ -5,6 +5,7 @@ import 'manage_products_page.dart';
 import 'manage_users_page.dart';
 import 'validate_prices_page.dart';
 import 'manage_stores_page.dart';
+import 'import_invoice_page.dart';
 
 class AdminHomePage extends StatelessWidget {
   const AdminHomePage({super.key});
@@ -83,6 +84,19 @@ class AdminHomePage extends StatelessWidget {
               },
               icon: const Icon(Icons.check),
               label: const Text('Validar Preços'),
+            ),
+            const SizedBox(height: AppTheme.paddingMedium),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const ImportInvoicePage(),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.file_upload),
+              label: const Text('Importar Nota Fiscal'),
             ),
           ],
         ),

--- a/lib/presentation/pages/admin/import_invoice_page.dart
+++ b/lib/presentation/pages/admin/import_invoice_page.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:html/parser.dart' as html_parser;
+import '../../../core/themes/app_theme.dart';
+
+class ImportInvoicePage extends StatefulWidget {
+  const ImportInvoicePage({super.key});
+
+  @override
+  State<ImportInvoicePage> createState() => _ImportInvoicePageState();
+}
+
+class _ImportInvoicePageState extends State<ImportInvoicePage> {
+  File? _selectedFile;
+  String? _message;
+
+  Future<void> _pickFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['html', 'htm', 'xml'],
+    );
+    if (result != null && result.files.single.path != null) {
+      setState(() {
+        _selectedFile = File(result.files.single.path!);
+        _message = null;
+      });
+    }
+  }
+
+  Future<void> _import() async {
+    if (_selectedFile == null) return;
+    final content = await _selectedFile!.readAsString();
+    if (_selectedFile!.path.toLowerCase().endsWith('.xml')) {
+      _parseXml(content);
+    } else {
+      _parseHtml(content);
+    }
+  }
+
+  void _parseHtml(String html) {
+    final document = html_parser.parse(html);
+    // TODO: Implementar extração de dados da nota fiscal em HTML
+    setState(() => _message = 'Arquivo HTML carregado (${document.body?.children.length} elementos)');
+  }
+
+  void _parseXml(String xml) {
+    // TODO: Implementar extração de dados da nota fiscal em XML
+    setState(() => _message = 'Arquivo XML carregado (${xml.length} caracteres)');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Importar Nota Fiscal')),
+      body: Padding(
+        padding: const EdgeInsets.all(AppTheme.paddingLarge),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ElevatedButton.icon(
+              onPressed: _pickFile,
+              icon: const Icon(Icons.upload_file),
+              label: const Text('Selecionar Arquivo'),
+            ),
+            if (_selectedFile != null) ...[
+              const SizedBox(height: AppTheme.paddingMedium),
+              Text(_selectedFile!.path),
+            ],
+            const SizedBox(height: AppTheme.paddingLarge),
+            ElevatedButton(
+              onPressed: _selectedFile != null ? _import : null,
+              child: const Text('Importar'),
+            ),
+            if (_message != null) ...[
+              const SizedBox(height: AppTheme.paddingMedium),
+              Text(_message!),
+            ]
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,8 @@ dependencies:
   equatable: ^2.0.5
   url_launcher: ^6.2.1
   flutter_dotenv: ^5.1.0
+  file_picker: ^6.1.1
+  html: ^0.15.4
 
   # UI e Animações
   lottie: ^2.7.0


### PR DESCRIPTION
## Summary
- add skeleton service to create stores, products, and prices when importing invoices
- add page with file picker and HTML parser for invoice import
- add button in admin home to open invoice import page
- add `file_picker` and `html` dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b4542ef4832fb53464c661cb2e37