### PR TITLE
Separate invoice import logic

### DIFF
--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../core/constants/enums.dart';
 
 /// Serviço auxiliar para criação de entidades ao importar notas fiscais.
 class InvoiceImportService {
@@ -78,6 +79,38 @@ class InvoiceImportService {
       'created_at': Timestamp.now(),
     };
     final doc = await _firestore.collection('prices').add(data);
+    return doc;
+  }
+
+  /// Cria ou retorna uma nota fiscal existente pela chave de acesso.
+  Future<DocumentReference<Map<String, dynamic>>> getOrCreateInvoice({
+    required String qrLink,
+    required String accessKey,
+    required String cnpj,
+    required String series,
+    required String number,
+    required String userId,
+  }) async {
+    final existing = await _firestore
+        .collection('invoices')
+        .where('access_key', isEqualTo: accessKey)
+        .limit(1)
+        .get();
+    if (existing.docs.isNotEmpty) {
+      return existing.docs.first.reference;
+    }
+
+    final data = {
+      'user_id': userId,
+      'qr_link': qrLink,
+      'access_key': accessKey,
+      'cnpj': cnpj,
+      'series': series,
+      'number': number,
+      'created_at': Timestamp.now(),
+      'status': ModerationStatus.underReview.value,
+    };
+    final doc = await _firestore.collection('invoices').add(data);
     return doc;
   }
 }

--- a/lib/data/parsers/invoice_html_parser.dart
+++ b/lib/data/parsers/invoice_html_parser.dart
@@ -1,0 +1,9 @@
+import 'package:html/parser.dart' as html_parser;
+
+class InvoiceHtmlParser {
+  static String parse(String html) {
+    final document = html_parser.parse(html);
+    // TODO: Implementar extração de dados da nota fiscal em HTML
+    return 'Arquivo HTML carregado (${document.body?.children.length} elementos)';
+  }
+}

--- a/lib/data/parsers/invoice_xml_parser.dart
+++ b/lib/data/parsers/invoice_xml_parser.dart
@@ -1,0 +1,6 @@
+class InvoiceXmlParser {
+  static String parse(String xml) {
+    // TODO: Implementar extração de dados da nota fiscal em XML
+    return 'Arquivo XML carregado (${xml.length} caracteres)';
+  }
+}

--- a/lib/presentation/pages/admin/import_invoice_page.dart
+++ b/lib/presentation/pages/admin/import_invoice_page.dart
@@ -2,8 +2,9 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:html/parser.dart' as html_parser;
 import '../../../core/themes/app_theme.dart';
+import '../../../data/parsers/invoice_html_parser.dart';
+import '../../../data/parsers/invoice_xml_parser.dart';
 
 class ImportInvoicePage extends StatefulWidget {
   const ImportInvoicePage({super.key});
@@ -33,21 +34,12 @@ class _ImportInvoicePageState extends State<ImportInvoicePage> {
     if (_selectedFile == null) return;
     final content = await _selectedFile!.readAsString();
     if (_selectedFile!.path.toLowerCase().endsWith('.xml')) {
-      _parseXml(content);
+      final msg = InvoiceXmlParser.parse(content);
+      setState(() => _message = msg);
     } else {
-      _parseHtml(content);
+      final msg = InvoiceHtmlParser.parse(content);
+      setState(() => _message = msg);
     }
-  }
-
-  void _parseHtml(String html) {
-    final document = html_parser.parse(html);
-    // TODO: Implementar extração de dados da nota fiscal em HTML
-    setState(() => _message = 'Arquivo HTML carregado (${document.body?.children.length} elementos)');
-  }
-
-  void _parseXml(String xml) {
-    // TODO: Implementar extração de dados da nota fiscal em XML
-    setState(() => _message = 'Arquivo XML carregado (${xml.length} caracteres)');
   }
 
   @override


### PR DESCRIPTION
## Summary
- provide HTML/XML invoice parser helpers
- refactor ImportInvoicePage to use parser helpers
- add getOrCreateInvoice to InvoiceImportService

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863b992e5e8832fa246a068ea81d0e1