### PR TITLE
Implement CPF utils and tests

### DIFF
--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -158,8 +158,16 @@ class Formatters {
     }
     return cep;
   }
+  // Formatação de CPF
+  static String formatCpf(String cpf) {
+    final cleanCpf = cpf.replaceAll(RegExp(r'[^\d]'), '');
+    if (cleanCpf.length == 11) {
+      return '${cleanCpf.substring(0, 3)}.${cleanCpf.substring(3, 6)}.${cleanCpf.substring(6, 9)}-${cleanCpf.substring(9)}';
+    }
+    return cpf;
+  }
 
-  // Formatação de CNPJ
+// Formatação de CNPJ
   static String formatCnpj(String cnpj) {
     final cleanCnpj = cnpj.replaceAll(RegExp(r'[^\d]'), '');
     if (cleanCnpj.length == 14) {

--- a/lib/core/utils/validators.dart
+++ b/lib/core/utils/validators.dart
@@ -196,7 +196,43 @@ class Validators {
     return null;
   }
 
-  // Validação de coordenadas
+  
+
+  // Validação de CPF
+  static String? validateCpf(String? cpf) {
+    if (cpf == null || cpf.isEmpty) {
+      return 'CPF é obrigatório';
+    }
+
+    final cleanCpf = cpf.replaceAll(RegExp(r'[^\d]'), '');
+    if (cleanCpf.length != 11) {
+      return 'CPF inválido';
+    }
+
+    if (RegExp(r'^(\d)\1*$').hasMatch(cleanCpf)) {
+      return 'CPF inválido';
+    }
+
+    int calcDigit(String base, int length) {
+      var sum = 0
+      for (var i = 0; i < length; i++) {
+        sum += int.parse(base[i]) * ((length + 1) - i);
+      }
+      final mod = sum % 11;
+      return mod < 2 ? 0 : 11 - mod;
+    }
+
+    final digit1 = calcDigit(cleanCpf, 9);
+    final digit2 = calcDigit(cleanCpf, 10);
+
+    if (digit1 != int.parse(cleanCpf[9]) || digit2 != int.parse(cleanCpf[10])) {
+      return 'CPF inválido';
+    }
+
+    return null;
+
+  }
+// Validação de coordenadas
   static String? validateLatitude(double? latitude) {
     if (latitude == null) {
       return 'Latitude é obrigatória';

--- a/test/formatters_test.dart
+++ b/test/formatters_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:precinho_app/core/utils/formatters.dart';
+
+void main() {
+  group('Formatters', () {
+    test('formatPrice and parsePrice', () {
+      final formatted = Formatters.formatPrice(10);
+      expect(formatted.contains('10,00'), isTrue);
+      expect(Formatters.parsePrice(formatted), 10);
+    });
+
+    test('formatPhone', () {
+      expect(Formatters.formatPhone('11987654321'), '(11) 98765-4321');
+    });
+
+    test('formatDistance', () {
+      expect(Formatters.formatDistance(0.5), '500m');
+      expect(Formatters.formatDistance(2), '2.0km');
+    });
+
+    test('formatCpf', () {
+      expect(Formatters.formatCpf('11144477735'), '111.444.777-35');
+    });
+  });
+}

--- a/test/validators_test.dart
+++ b/test/validators_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:precinho_app/core/utils/validators.dart';
+
+void main() {
+  group('Validators', () {
+    test('validateEmail', () {
+      expect(Validators.validateEmail('test@example.com'), isNull);
+      expect(Validators.validateEmail('invalid'), isNotNull);
+    });
+
+    test('validatePassword', () {
+      expect(Validators.validatePassword('123456'), isNull);
+      expect(Validators.validatePassword('123'), isNotNull);
+    });
+
+    test('validatePrice', () {
+      expect(Validators.validatePrice('10,50'), isNull);
+      expect(Validators.validatePrice('-1'), isNotNull);
+    });
+
+    test('validateCpf', () {
+      expect(Validators.validateCpf('111.444.777-35'), isNull);
+      expect(Validators.validateCpf('123.456.789-00'), isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- extend `Validators` with a new `validateCpf` method for Brazilian CPF
- extend `Formatters` with a new `formatCpf` helper
- cover validators and formatters with unit tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686694aef43c832fbef5dbf3aa79cbac