### PR TITLE
Fix validator syntax

### DIFF
--- a/lib/core/utils/validators.dart
+++ b/lib/core/utils/validators.dart
@@ -214,7 +214,7 @@ class Validators {
     }
 
     int calcDigit(String base, int length) {
-      var sum = 0
+      var sum = 0;
       for (var i = 0; i < length; i++) {
         sum += int.parse(base[i]) * ((length + 1) - i);
       }


### PR DESCRIPTION
## Summary
- add missing semicolon in `validators.dart`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866974b48e0832faff320779f4ffc36