### PR TITLE
Fix Firebase initialization on web

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,6 @@ void main() async {
 
   if (Firebase.apps.isEmpty) {
     await Firebase.initializeApp(
-      name: 'Precinho',
       options: DefaultFirebaseOptions.currentPlatform,
     );
   }


### PR DESCRIPTION
## Summary
- initialize Firebase with default app name

## Testing
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686686aa796c832fb631c2c02f1688f1