### PR TITLE
Implement store import for invoice HTML

### DIFF
--- a/lib/data/parsers/invoice_html_parser.dart
+++ b/lib/data/parsers/invoice_html_parser.dart
@@ -23,10 +23,15 @@ class InvoiceHtmlParser {
     return data;
   }
 
+  /// Returns all key/value pairs extracted from the HTML.
+  static Map<String, String> extractFields(String html) {
+    final document = html_parser.parse(html);
+    return _extractFields(document);
+  }
+
   /// Parses the HTML of an NFC-e file and returns a short summary message.
   static String parse(String html) {
-    final document = html_parser.parse(html);
-    final fields = _extractFields(document);
+    final fields = extractFields(html);
 
     final numero = fields['Número NFC-e'] ?? fields['Número'];
     final total =

--- a/lib/presentation/pages/admin/import_invoice_page.dart
+++ b/lib/presentation/pages/admin/import_invoice_page.dart
@@ -7,6 +7,7 @@ import 'package:file_picker/file_picker.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../data/parsers/invoice_html_parser.dart';
 import '../../../data/parsers/invoice_xml_parser.dart';
+import '../../../data/datasources/invoice_import_service.dart';
 
 class ImportInvoicePage extends StatefulWidget {
   const ImportInvoicePage({super.key});
@@ -48,8 +49,18 @@ class _ImportInvoicePageState extends State<ImportInvoicePage> {
       final msg = InvoiceXmlParser.parse(content);
       setState(() => _message = msg);
     } else {
+      final fields = InvoiceHtmlParser.extractFields(content);
       final msg = InvoiceHtmlParser.parse(content);
       setState(() => _message = msg);
+
+      final cnpj = fields['CNPJ'];
+      final name = fields['Razão Social'] ?? fields['Nome / Razão Social'] ??
+          fields['Nome'] ?? 'Desconhecido';
+      final address = fields['Endereço'];
+      if (cnpj != null) {
+        await InvoiceImportService()
+            .getOrCreateStore(cnpj: cnpj, name: name, address: address);
+      }
     }
   }
 

--- a/test/invoice_html_parser_test.dart
+++ b/test/invoice_html_parser_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:precinho_app/data/parsers/invoice_html_parser.dart';
+
+void main() {
+  test('extractFields parses CNPJ', () {
+    const html = '''
+<div class="col">
+  <div class="sub-titulo">CNPJ</div>
+  <div class="campo-xml">12345678000190</div>
+</div>
+<div class="col">
+  <div class="sub-titulo">Número</div>
+  <div class="campo-xml">1</div>
+</div>
+<div class="col">
+  <div class="sub-titulo">Valor Total da Nota Fiscal</div>
+  <div class="campo-xml">1,00</div>
+</div>
+''';
+    final fields = InvoiceHtmlParser.extractFields(html);
+    expect(fields['CNPJ'], '12345678000190');
+    final summary = InvoiceHtmlParser.parse(html);
+    expect(summary.contains('Total'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- expose a helper to get all parsed fields from invoice HTML
- on ImportInvoicePage, create a store using the CNPJ field when importing HTML invoices
- add a test for InvoiceHtmlParser

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868492780d4832fa8ce6d78f47e324f