### PR TITLE
Implement invoice import workflow

### DIFF
--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -65,12 +65,14 @@ class InvoiceImportService {
     String? customCode,
     required double value,
     required String description,
+    required DocumentReference invoiceRef,
     required DocumentReference storeRef,
     required DocumentReference productRef,
   }) async {
     final data = {
       'product_id': productRef.id,
       'store_id': storeRef.id,
+      'invoice_id': invoiceRef.id,
       'price': value,
       'description': description,
       if (ncm != null) 'ncm_code': ncm,

--- a/lib/presentation/pages/admin/import_invoice_page.dart
+++ b/lib/presentation/pages/admin/import_invoice_page.dart
@@ -7,7 +7,6 @@ import 'package:file_picker/file_picker.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../data/parsers/invoice_html_parser.dart';
 import '../../../data/parsers/invoice_xml_parser.dart';
-import '../../../data/datasources/invoice_import_service.dart';
 
 class ImportInvoicePage extends StatefulWidget {
   const ImportInvoicePage({super.key});
@@ -49,18 +48,11 @@ class _ImportInvoicePageState extends State<ImportInvoicePage> {
       final msg = InvoiceXmlParser.parse(content);
       setState(() => _message = msg);
     } else {
-      final fields = InvoiceHtmlParser.extractFields(content);
-      final msg = InvoiceHtmlParser.parse(content);
+      final msg = await InvoiceHtmlParser.importInvoice(
+        content,
+        userId: 'system',
+      );
       setState(() => _message = msg);
-
-      final cnpj = fields['CNPJ'];
-      final name = fields['Razão Social'] ?? fields['Nome / Razão Social'] ??
-          fields['Nome'] ?? 'Desconhecido';
-      final address = fields['Endereço'];
-      if (cnpj != null) {
-        await InvoiceImportService()
-            .getOrCreateStore(cnpj: cnpj, name: name, address: address);
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- link invoice parser to Firestore
- add invoice reference when creating prices
- update admin invoice import page to use new logic

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699f688cd4832f869c91045a6b417e