### PR TITLE
Fix invoice import field types

### DIFF
--- a/lib/presentation/pages/admin/import_invoice_page.dart
+++ b/lib/presentation/pages/admin/import_invoice_page.dart
@@ -53,10 +53,12 @@ class _ImportInvoicePageState extends State<ImportInvoicePage> {
       final msg = InvoiceHtmlParser.parse(content);
       setState(() => _message = msg);
 
-      final cnpj = fields['CNPJ'];
-      final name = fields['Razão Social'] ?? fields['Nome / Razão Social'] ??
-          fields['Nome'] ?? 'Desconhecido';
-      final address = fields['Endereço'];
+      final cnpj = fields['CNPJ']?.first;
+      final name = (fields['Razão Social']?.first ??
+              fields['Nome / Razão Social']?.first ??
+              fields['Nome']?.first) ??
+          'Desconhecido';
+      final address = fields['Endereço']?.first;
       if (cnpj != null) {
         await InvoiceImportService()
             .getOrCreateStore(cnpj: cnpj, name: name, address: address);


### PR DESCRIPTION
## Summary
- use first value from parsed fields when importing invoice html

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a70263d8832fb267b42f686826d2