### PR TITLE
Set approved status when importing invoice HTML

### DIFF
--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -75,6 +75,7 @@ class InvoiceImportService {
       'invoice_id': invoiceRef.id,
       'price': value,
       'description': description,
+      'status': ModerationStatus.approved.value,
       if (ncm != null) 'ncm_code': ncm,
       if (ean != null) 'ean_code': ean,
       if (customCode != null) 'custom_code': customCode,

--- a/lib/data/parsers/invoice_html_parser.dart
+++ b/lib/data/parsers/invoice_html_parser.dart
@@ -1,6 +1,7 @@
 import 'package:html/parser.dart' as html_parser;
 import 'package:html/dom.dart';
 import '../datasources/invoice_import_service.dart';
+import '../../core/constants/enums.dart';
 
 class InvoiceHtmlParser {
   /// Converte string com vírgula em double. Ex: "1.234,56" => 1234.56
@@ -183,6 +184,12 @@ class InvoiceHtmlParser {
       userId: userId,
     );
 
+    final invoiceSnap = await invoiceRef.get();
+    final currentStatus = invoiceSnap.data()?['status'] as String?;
+    if (currentStatus == ModerationStatus.approved.value) {
+      throw Exception('Invoice j\u00e1 aprovada');
+    }
+
     final eans = produtos['Código EAN Comercial'] ?? [];
     final ncms = produtos['Código NCM'] ?? [];
     final codigos = produtos['Código do produto'] ?? [];
@@ -216,6 +223,8 @@ class InvoiceHtmlParser {
         productRef: productRef,
       );
     }
+
+    await invoiceRef.update({'status': ModerationStatus.approved.value});
 
     return '$nItens preços importados';
   }


### PR DESCRIPTION
## Summary
- mark imported prices as `approved`
- prevent importing HTML for invoices already approved
- update invoice status to `approved` after import

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a4215a520832fa2e3ec986977730f