### PR TITLE
Implement store product mapping for invoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ flutter run
 ### Configuração do Firebase
 
 1. **Firestore Database:**
-   - Crie as coleções: `users`, `products`, `stores`, `prices`
+   - Crie as coleções: `users`, `products`, `stores`, `prices`, `store_products`
    - As listas de compras agora são armazenadas apenas no dispositivo e não
      precisam de coleção em banco de dados
    - Configure as regras de segurança

--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -33,12 +33,30 @@ class InvoiceImportService {
     return doc;
   }
 
-  /// Cria ou retorna um produto existente pelo EAN ou NCM.
+  /// Cria ou retorna um produto existente pelo EAN/NCM ou c\u00f3digo do com\u00e9rcio.
   Future<DocumentReference<Map<String, dynamic>>> getOrCreateProduct({
     String? ean,
     String? ncm,
     required String name,
+    DocumentReference<Map<String, dynamic>>? storeRef,
+    String? storeCode,
+    String? storeDescription,
   }) async {
+    // Primeiro tenta encontrar pelo c\u00f3digo vinculado ao com\u00e9rcio
+    if (storeRef != null && storeCode != null && storeCode.isNotEmpty) {
+      final mappingSnap = await _firestore
+          .collection('store_products')
+          .where('store_id', isEqualTo: storeRef.id)
+          .where('code', isEqualTo: storeCode)
+          .limit(1)
+          .get();
+      if (mappingSnap.docs.isNotEmpty) {
+        final productId = mappingSnap.docs.first.data()['product_id'] as String;
+        return _firestore.collection('products').doc(productId);
+      }
+    }
+
+    // Depois busca pelos atributos do produto (EAN ou NCM)
     Query<Map<String, dynamic>> query = _firestore.collection('products');
     if (ean != null && ean.isNotEmpty) {
       query = query.where('barcode', isEqualTo: ean);
@@ -46,16 +64,39 @@ class InvoiceImportService {
       query = query.where('ncm_code', isEqualTo: ncm);
     }
     final snap = await query.limit(1).get();
-    if (snap.docs.isNotEmpty) return snap.docs.first.reference;
+    DocumentReference<Map<String, dynamic>> productRef;
+    if (snap.docs.isNotEmpty) {
+      productRef = snap.docs.first.reference;
+    } else {
+      final data = {
+        'name': name,
+        if (ean != null) 'barcode': ean,
+        if (ncm != null) 'ncm_code': ncm,
+        'created_at': Timestamp.now(),
+      };
+      productRef = await _firestore.collection('products').add(data);
+    }
 
-    final data = {
-      'name': name,
-      if (ean != null) 'barcode': ean,
-      if (ncm != null) 'ncm_code': ncm,
-      'created_at': Timestamp.now(),
-    };
-    final doc = await _firestore.collection('products').add(data);
-    return doc;
+    // Se houver informa\u00e7\u00f5es do c\u00f3digo do com\u00e9rcio, cria o v\u00ednculo
+    if (storeRef != null && storeCode != null && storeCode.isNotEmpty) {
+      final mappingSnap = await _firestore
+          .collection('store_products')
+          .where('store_id', isEqualTo: storeRef.id)
+          .where('code', isEqualTo: storeCode)
+          .limit(1)
+          .get();
+      if (mappingSnap.docs.isEmpty) {
+        await _firestore.collection('store_products').add({
+          'store_id': storeRef.id,
+          'product_id': productRef.id,
+          'code': storeCode,
+          'description': storeDescription ?? name,
+          'created_at': Timestamp.now(),
+        });
+      }
+    }
+
+    return productRef;
   }
 
   /// Cria um preço vinculado a um produto e comércio existentes.

--- a/lib/data/parsers/invoice_html_parser.dart
+++ b/lib/data/parsers/invoice_html_parser.dart
@@ -210,6 +210,9 @@ class InvoiceHtmlParser {
         ean: ean?.isNotEmpty == true ? ean : null,
         ncm: ncm?.isNotEmpty == true ? ncm : null,
         name: descricao,
+        storeRef: storeRef,
+        storeCode: codigo,
+        storeDescription: descricao,
       );
 
       await service.createPrice(


### PR DESCRIPTION
## Summary
- link store-specific product codes to products
- use the mapping when parsing invoice prices
- document new `store_products` collection in README

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5fbbcd30832f839d7af63570fff9