### PR TITLE
Add admin page to edit store product codes

### DIFF
--- a/lib/presentation/pages/admin/admin_home_page.dart
+++ b/lib/presentation/pages/admin/admin_home_page.dart
@@ -6,6 +6,7 @@ import 'manage_users_page.dart';
 import 'validate_prices_page.dart';
 import 'manage_stores_page.dart';
 import 'import_invoice_page.dart';
+import 'manage_store_codes_page.dart';
 
 class AdminHomePage extends StatelessWidget {
   const AdminHomePage({super.key});
@@ -45,6 +46,19 @@ class AdminHomePage extends StatelessWidget {
               },
               icon: const Icon(Icons.store),
               label: const Text('Gerenciar Com\u00e9rcios'),
+            ),
+            const SizedBox(height: AppTheme.paddingMedium),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const ManageStoreCodesPage(),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.code),
+              label: const Text('Gerenciar C\u00f3digos'),
             ),
             const SizedBox(height: AppTheme.paddingMedium),
             ElevatedButton.icon(

--- a/lib/presentation/pages/admin/edit_store_code_page.dart
+++ b/lib/presentation/pages/admin/edit_store_code_page.dart
@@ -1,0 +1,130 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/logging/firebase_logger.dart';
+import '../product/product_search_page.dart';
+
+class EditStoreCodePage extends StatefulWidget {
+  final DocumentSnapshot document;
+  const EditStoreCodePage({super.key, required this.document});
+
+  @override
+  State<EditStoreCodePage> createState() => _EditStoreCodePageState();
+}
+
+class _EditStoreCodePageState extends State<EditStoreCodePage> {
+  String? _storeName;
+  DocumentSnapshot? _productDoc;
+  late final String _code;
+  late final String _description;
+
+  @override
+  void initState() {
+    super.initState();
+    final data = widget.document.data() as Map<String, dynamic>;
+    _code = data['code'] as String? ?? '';
+    _description = data['description'] as String? ?? '';
+    FirebaseFirestore.instance
+        .collection('stores')
+        .doc(data['store_id'])
+        .get()
+        .then((doc) {
+      if (mounted) {
+        setState(() {
+          _storeName = (doc.data() as Map<String, dynamic>?)?['name'];
+        });
+      }
+    });
+    FirebaseFirestore.instance
+        .collection('products')
+        .doc(data['product_id'])
+        .get()
+        .then((doc) {
+      if (mounted) {
+        setState(() {
+          _productDoc = doc;
+        });
+      }
+    });
+  }
+
+  Future<void> _selectProduct() async {
+    final doc = await Navigator.push<DocumentSnapshot>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ProductSearchPage(
+          onSelected: (p) => Navigator.pop(context, p),
+        ),
+      ),
+    );
+    if (doc != null) {
+      setState(() {
+        _productDoc = doc;
+      });
+    }
+  }
+
+  Future<void> _submit() async {
+    if (_productDoc == null) return;
+    try {
+      FirebaseLogger.log('Updating store code', {'id': widget.document.id});
+      await widget.document.reference.update({'product_id': _productDoc!.id});
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Código atualizado')),
+      );
+      Navigator.pop(context);
+    } catch (e) {
+      FirebaseLogger.log('Edit store code error', {'error': e.toString()});
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Erro ao atualizar: $e'),
+          backgroundColor: AppTheme.errorColor,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final productName = _productDoc != null
+        ? ((_productDoc!.data() as Map<String, dynamic>)['name'] ?? '')
+        : '';
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Editar Código Próprio'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(AppTheme.paddingLarge),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('Comércio: ${_storeName ?? ''}'),
+            const SizedBox(height: AppTheme.paddingMedium),
+            Text('Código: $_code'),
+            const SizedBox(height: AppTheme.paddingMedium),
+            Text('Descrição: $_description'),
+            const SizedBox(height: AppTheme.paddingLarge),
+            ElevatedButton(
+              onPressed: _selectProduct,
+              child: const Text('Selecionar Produto'),
+            ),
+            if (productName.isNotEmpty) ...[
+              const SizedBox(height: AppTheme.paddingMedium),
+              Text('Produto selecionado: $productName'),
+            ],
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _productDoc != null ? _submit : null,
+                child: const Text('Salvar'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/admin/manage_store_codes_page.dart
+++ b/lib/presentation/pages/admin/manage_store_codes_page.dart
@@ -1,0 +1,84 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import '../../../core/themes/app_theme.dart';
+import 'edit_store_code_page.dart';
+
+class ManageStoreCodesPage extends StatefulWidget {
+  const ManageStoreCodesPage({super.key});
+
+  @override
+  State<ManageStoreCodesPage> createState() => _ManageStoreCodesPageState();
+}
+
+class _ManageStoreCodesPageState extends State<ManageStoreCodesPage> {
+  final Map<String, String> _storeNames = {};
+  final Map<String, String> _productNames = {};
+
+  Future<void> _loadNames(String storeId, String productId) async {
+    if (!_storeNames.containsKey(storeId)) {
+      final doc = await FirebaseFirestore.instance.collection('stores').doc(storeId).get();
+      _storeNames[storeId] = (doc.data() as Map<String, dynamic>?)?['name'] ?? storeId;
+    }
+    if (!_productNames.containsKey(productId)) {
+      final doc = await FirebaseFirestore.instance.collection('products').doc(productId).get();
+      _productNames[productId] = (doc.data() as Map<String, dynamic>?)?['name'] ?? productId;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Códigos Próprios'),
+      ),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('store_products')
+            .orderBy('code')
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return const Center(child: Text('Erro ao carregar códigos'));
+          }
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('Nenhum código cadastrado'));
+          }
+          return ListView.builder(
+            itemCount: docs.length,
+            itemBuilder: (context, index) {
+              final doc = docs[index];
+              final data = doc.data() as Map<String, dynamic>;
+              final storeId = data['store_id'] as String? ?? '';
+              final productId = data['product_id'] as String? ?? '';
+
+              if (!_storeNames.containsKey(storeId) || !_productNames.containsKey(productId)) {
+                _loadNames(storeId, productId).then((_) => setState(() {}));
+              }
+
+              final storeName = _storeNames[storeId] ?? storeId;
+              final productName = _productNames[productId] ?? productId;
+
+              return ListTile(
+                leading: const Icon(Icons.code, color: AppTheme.primaryColor),
+                title: Text('${data['code']} - $storeName'),
+                subtitle: Text(productName),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => EditStoreCodePage(document: doc),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow administrators to change which product a custom store code points to
- list all custom codes and link to an edit page
- add navigation from the admin home page

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6c85e1b4832f84df6eb68dc9038b