### PR TITLE
Add ncm/ean to store codes and store location on prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,20 @@ crie um novo `Store` anônimo contendo as coordenadas do local. É possível
 cadastrar quantos comércios anônimos forem necessários, cada um com um
 `id` distinto e sua respectiva localização.
 
+### StoreProductCode (Código Próprio do Comércio)
+```dart
+class StoreProductCode {
+  final String id;
+  final String storeId;
+  final String productId;
+  final String code;
+  final String description;
+  final String? ncmCode;
+  final String? eanCode;
+  final DateTime createdAt;
+}
+```
+
 ### Price (Preço)
 ```dart
 class Price {
@@ -255,8 +269,8 @@ class Price {
   final String userId;
   final double value;
   final String? imageUrl;
-  final double? latitude;
-  final double? longitude;
+  final double? latitude; // localização do comércio
+  final double? longitude; // localização do comércio
   final DateTime createdAt;
   final DateTime? expiresAt;
   final ModerationStatus status;

--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -91,6 +91,8 @@ class InvoiceImportService {
           'product_id': productRef.id,
           'code': storeCode,
           'description': storeDescription ?? name,
+          if (ncm != null) 'ncm_code': ncm,
+          if (ean != null) 'ean_code': ean,
           'created_at': Timestamp.now(),
         });
       }
@@ -112,6 +114,8 @@ class InvoiceImportService {
   }) async {
     final productSnap = await productRef.get();
     final productData = productSnap.data() ?? <String, dynamic>{};
+    final storeSnap = await storeRef.get();
+    final storeData = storeSnap.data() ?? <String, dynamic>{};
 
     final data = {
       'product_id': productRef.id,
@@ -122,6 +126,10 @@ class InvoiceImportService {
       'product_name': productData['name'],
       'image_url': productData['image_url'],
       'status': ModerationStatus.approved.value,
+      if (storeData['latitude'] != null)
+        'latitude': (storeData['latitude'] as num).toDouble(),
+      if (storeData['longitude'] != null)
+        'longitude': (storeData['longitude'] as num).toDouble(),
       if (ncm != null) 'ncm_code': ncm,
       if (ean != null) 'ean_code': ean,
       if (customCode != null) 'custom_code': customCode,

--- a/lib/presentation/pages/admin/manage_store_codes_page.dart
+++ b/lib/presentation/pages/admin/manage_store_codes_page.dart
@@ -65,7 +65,9 @@ class _ManageStoreCodesPageState extends State<ManageStoreCodesPage> {
               return ListTile(
                 leading: const Icon(Icons.code, color: AppTheme.primaryColor),
                 title: Text('${data['code']} - $storeName'),
-                subtitle: Text(productName),
+                subtitle: Text(
+                  '$productName\nNCM: ${data['ncm_code'] ?? '-'} | EAN: ${data['ean_code'] ?? '-'}',
+                ),
                 onTap: () {
                   Navigator.push(
                     context,

--- a/lib/presentation/pages/price/add_price_page.dart
+++ b/lib/presentation/pages/price/add_price_page.dart
@@ -193,10 +193,16 @@ class _AddPricePageState extends State<AddPricePage> {
           'image_url': null,
           'created_at': Timestamp.now(),
           if (variation != null) 'variation': variation,
-          if (position != null) ...{
-            'latitude': position.latitude,
-            'longitude': position.longitude,
-          },
+          if (storeData['latitude'] != null && storeData['longitude'] != null)
+            ...{
+              'latitude': (storeData['latitude'] as num).toDouble(),
+              'longitude': (storeData['longitude'] as num).toDouble(),
+            }
+          else if (position != null)
+            ...{
+              'latitude': position.latitude,
+              'longitude': position.longitude,
+            },
         };
         FirebaseLogger.log('Adding price', data);
         await FirebaseFirestore.instance.collection('prices').add(data);


### PR DESCRIPTION
## Summary
- extend store product code with NCM and EAN
- include store coordinates when saving a price
- show NCM and EAN fields on admin page
- document new data model in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d858708d4832fb4ae29df16587d5f