### PR TITLE
Add optional brand and NCM in edit page

### DIFF
--- a/lib/core/utils/validators.dart
+++ b/lib/core/utils/validators.dart
@@ -182,6 +182,37 @@ class Validators {
     return null;
   }
 
+  // Validação de marca (opcional)
+  static String? validateBrand(String? brand) {
+    if (brand == null || brand.isEmpty) {
+      return null; // Marca é opcional
+    }
+
+    if (brand.length < 2) {
+      return 'Marca deve ter pelo menos 2 caracteres';
+    }
+
+    if (brand.length > AppConstants.maxProductNameLength) {
+      return 'Marca deve ter no máximo ${AppConstants.maxProductNameLength} caracteres';
+    }
+
+    return null;
+  }
+
+  // Validação de código NCM (opcional)
+  static String? validateNcmCode(String? ncm) {
+    if (ncm == null || ncm.isEmpty) {
+      return null;
+    }
+
+    final clean = ncm.replaceAll(RegExp(r'[^\d]'), '');
+    if (clean.length != 8) {
+      return 'NCM deve ter 8 dígitos';
+    }
+
+    return null;
+  }
+
   // Validação de CNPJ
   static String? validateCnpj(String? cnpj) {
     if (cnpj == null || cnpj.isEmpty) {

--- a/lib/presentation/pages/admin/edit_product_page.dart
+++ b/lib/presentation/pages/admin/edit_product_page.dart
@@ -26,6 +26,7 @@ class _EditProductPageState extends State<EditProductPage> {
   late final TextEditingController _brandController;
   late final TextEditingController _volumeController;
   late final TextEditingController _barcodeController;
+  late final TextEditingController _ncmController;
   late final TextEditingController _descriptionController;
   final ImagePicker _picker = ImagePicker();
   XFile? _imageFile;
@@ -46,6 +47,7 @@ class _EditProductPageState extends State<EditProductPage> {
     _volumeController =
         TextEditingController(text: data['volume']?.toString() ?? '');
     _barcodeController = TextEditingController(text: data['barcode'] ?? '');
+    _ncmController = TextEditingController(text: data['ncm_code'] ?? '');
     _descriptionController =
         TextEditingController(text: data['description'] ?? '');
     if (data['unit'] != null) {
@@ -79,6 +81,7 @@ class _EditProductPageState extends State<EditProductPage> {
     _brandController.dispose();
     _volumeController.dispose();
     _barcodeController.dispose();
+    _ncmController.dispose();
     _descriptionController.dispose();
     _categoryController.dispose();
     super.dispose();
@@ -143,6 +146,7 @@ class _EditProductPageState extends State<EditProductPage> {
           'volume': double.tryParse(_volumeController.text.trim()),
           'unit': _unit,
           'barcode': _barcodeController.text.trim(),
+          'ncm_code': _ncmController.text.trim(),
           'description': _descriptionController.text.trim(),
           'categories': _categories,
           'image_url': imageUrl,
@@ -218,7 +222,7 @@ class _EditProductPageState extends State<EditProductPage> {
                   labelText: 'Marca',
                   prefixIcon: Icon(Icons.business),
                 ),
-                validator: Validators.validateProductName,
+                validator: Validators.validateBrand,
               ),
               const SizedBox(height: AppTheme.paddingMedium),
               TextFormField(
@@ -258,6 +262,16 @@ class _EditProductPageState extends State<EditProductPage> {
                 ),
                 keyboardType: TextInputType.number,
                 validator: Validators.validateBarcode,
+              ),
+              const SizedBox(height: AppTheme.paddingMedium),
+              TextFormField(
+                controller: _ncmController,
+                decoration: const InputDecoration(
+                  labelText: 'NCM',
+                  prefixIcon: Icon(Icons.numbers),
+                ),
+                keyboardType: TextInputType.number,
+                validator: Validators.validateNcmCode,
               ),
               const SizedBox(height: AppTheme.paddingMedium),
               TextFormField(


### PR DESCRIPTION
## Summary
- allow optional brand validation and add NCM validation
- include NCM controller and field when editing products
- dispose new controller and send `ncm_code` when saving
- brand field now optional while editing

## Testing
- `flutter test` *(fails: flutter not installed)*
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d962ba6b0832fb622f9b96fea3f31