### PR TITLE
Add invoice management admin page

### DIFF
--- a/lib/presentation/pages/admin/admin_home_page.dart
+++ b/lib/presentation/pages/admin/admin_home_page.dart
@@ -4,6 +4,7 @@ import 'add_product_page.dart';
 import 'manage_products_page.dart';
 import 'manage_users_page.dart';
 import 'validate_prices_page.dart';
+import 'manage_invoices_page.dart';
 import 'manage_stores_page.dart';
 import 'import_invoice_page.dart';
 import 'manage_store_codes_page.dart';
@@ -98,6 +99,19 @@ class AdminHomePage extends StatelessWidget {
               },
               icon: const Icon(Icons.check),
               label: const Text('Validar Preços'),
+            ),
+            const SizedBox(height: AppTheme.paddingMedium),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const ManageInvoicesPage(),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.receipt_long),
+              label: const Text('Notas Fiscais'),
             ),
             const SizedBox(height: AppTheme.paddingMedium),
             ElevatedButton.icon(

--- a/lib/presentation/pages/admin/manage_invoices_page.dart
+++ b/lib/presentation/pages/admin/manage_invoices_page.dart
@@ -1,0 +1,123 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../core/constants/enums.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/utils/formatters.dart';
+import '../invoice/invoice_detail_page.dart';
+import 'import_invoice_page.dart';
+
+class ManageInvoicesPage extends StatefulWidget {
+  const ManageInvoicesPage({super.key});
+
+  @override
+  State<ManageInvoicesPage> createState() => _ManageInvoicesPageState();
+}
+
+class _ManageInvoicesPageState extends State<ManageInvoicesPage> {
+  bool _pendingOnly = false;
+
+  Stream<QuerySnapshot> get _invoiceStream {
+    Query<Map<String, dynamic>> query = FirebaseFirestore.instance
+        .collection('invoices')
+        .orderBy('created_at', descending: true);
+    if (_pendingOnly) {
+      query =
+          query.where('status', isEqualTo: ModerationStatus.underReview.value);
+    }
+    return query.snapshots();
+  }
+
+  Future<void> _openLink(String? urlStr) async {
+    if (urlStr == null || urlStr.isEmpty) return;
+    final url = Uri.parse(urlStr);
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Notas Fiscais'),
+      ),
+      body: Column(
+        children: [
+          SwitchListTile(
+            title: const Text('Mostrar apenas pendentes'),
+            value: _pendingOnly,
+            onChanged: (v) => setState(() => _pendingOnly = v),
+          ),
+          Expanded(
+            child: StreamBuilder<QuerySnapshot>(
+              stream: _invoiceStream,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                if (snapshot.hasError) {
+                  return const Center(child: Text('Erro ao carregar notas'));
+                }
+                final docs = snapshot.data?.docs ?? [];
+                if (docs.isEmpty) {
+                  return const Center(child: Text('Nenhuma nota fiscal encontrada'));
+                }
+                return ListView.builder(
+                  padding: const EdgeInsets.all(AppTheme.paddingMedium),
+                  itemCount: docs.length,
+                  itemBuilder: (context, index) {
+                    final doc = docs[index];
+                    final data = doc.data() as Map<String, dynamic>;
+                    final date = (data['created_at'] as Timestamp?)?.toDate();
+                    final status = ModerationStatus.values.firstWhere(
+                      (s) => s.value == data['status'],
+                      orElse: () => ModerationStatus.underReview,
+                    );
+                    return Card(
+                      child: ListTile(
+                        title: Text('Série ${data['series']} - Nº ${data['number']}'),
+                        subtitle: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            if (date != null)
+                              Text(Formatters.formatDateTime(date)),
+                            Text(status.displayName),
+                          ],
+                        ),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.link),
+                          onPressed: () => _openLink(data['qr_link'] as String?),
+                        ),
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => InvoiceDetailPage(invoiceId: doc.id),
+                            ),
+                          );
+                        },
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        heroTag: 'manage_invoices_import_fab',
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const ImportInvoicePage()),
+          );
+        },
+        child: const Icon(Icons.file_upload),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `ManageInvoicesPage` for admin section
- add pending filter and link opening support
- add shortcut button in admin home to access invoices page

## Testing
- `flutter format lib/presentation/pages/admin/manage_invoices_page.dart lib/presentation/pages/admin/admin_home_page.dart` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686da730f0f0832fbde058a3a003ef58