### PR TITLE
Fix createPrice parameter types

### DIFF
--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -108,9 +108,9 @@ class InvoiceImportService {
     String? customCode,
     required double value,
     required String description,
-    required DocumentReference invoiceRef,
-    required DocumentReference storeRef,
-    required DocumentReference productRef,
+    required DocumentReference<Map<String, dynamic>> invoiceRef,
+    required DocumentReference<Map<String, dynamic>> storeRef,
+    required DocumentReference<Map<String, dynamic>> productRef,
   }) async {
     final productSnap = await productRef.get();
     final productData = productSnap.data() ?? <String, dynamic>{};


### PR DESCRIPTION
## Summary
- fix type mismatch in InvoiceImportService.createPrice by specifying generic types for the `DocumentReference` parameters

## Testing
- `flutter test` *(fails: command not found)*
- `flutter test integration_test/` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dc54e27f0832fb0a55047324a7b49