### PR TITLE
Add button to fetch product image from Cosmos

### DIFF
--- a/lib/presentation/pages/admin/edit_product_page.dart
+++ b/lib/presentation/pages/admin/edit_product_page.dart
@@ -149,6 +149,41 @@ class _EditProductPageState extends State<EditProductPage> {
     }
   }
 
+  Future<void> _updateImageFromCosmos() async {
+    final ean = _barcodeController.text.trim();
+    if (ean.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Informe o codigo de barras')),
+      );
+      return;
+    }
+    try {
+      final data = await CosmosService().fetchProduct(ean);
+      if (data == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Produto nao encontrado')),
+        );
+        return;
+      }
+      final product = data['product'] as Map<String, dynamic>? ?? data;
+      final picture = product['picture'] ?? data['thumbnail'];
+      if (picture is String && picture.isNotEmpty) {
+        setState(() {
+          _imageUrl = picture;
+          _imageFile = null;
+        });
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Imagem nao encontrada')),
+        );
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Erro ao consultar Cosmos: $e')),
+      );
+    }
+  }
+
   void _addCategory() {
     final text = _categoryController.text.trim();
     if (text.isNotEmpty && !_categories.contains(text)) {
@@ -379,6 +414,10 @@ class _EditProductPageState extends State<EditProductPage> {
               OutlinedButton(
                 onPressed: _pickImage,
                 child: const Text('Selecionar Foto'),
+              ),
+              OutlinedButton(
+                onPressed: _updateImageFromCosmos,
+                child: const Text('Atualizar Imagem'),
               ),
               if (_imageFile != null)
                 ...[


### PR DESCRIPTION
## Summary
- add `_imageUrl` field in `AddProductPage`
- fetch Cosmos image via new `_updateImageFromCosmos` in add/edit product pages
- display network image when available
- adjust submit logic to save Cosmos image URL

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd089841c832f89026649a811a0ca