### PR TITLE
Implement Google user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ O aplicativo segue uma identidade visual inspirada em economia colaborativa e si
 - Cadastro de novos usuários
 - Login social com Google
 - Recuperação de senha
+- Contas Google registradas automaticamente para administração
 
 ### 🗺️ Mapa de Preços
 - Visualização de preços em mapa interativo
@@ -295,6 +296,7 @@ alteradas posteriormente.
 - [x] Tema e design system
 - [x] Validações e formatadores
 - [x] Página de administração com gestão de produtos via Firestore
+- [x] Gerenciamento de usuários (incluindo contas Google)
 - [x] Tela de cadastro dedicada para a versão web
 - [x] Envio de preços para o Firestore com mensagens de sucesso ou erro
 


### PR DESCRIPTION
## Summary
- ensure Google sign-in users have a Firestore user document
- document auto-registration for Google accounts
- note user management including Google accounts in feature list

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5cde2eb4832f924c7d1208531eec