### PR TITLE
Fix build error with file_picker on Android

### DIFF
--- a/android/app/src/main/java/io/flutter/plugin/common/PluginRegistry.java
+++ b/android/app/src/main/java/io/flutter/plugin/common/PluginRegistry.java
@@ -1,0 +1,14 @@
+package io.flutter.plugin.common;
+
+/**
+ * Minimal stub for Flutter's legacy PluginRegistry. This is needed
+ * for compatibility with old plugins that still declare a
+ * `registerWith(PluginRegistry.Registrar registrar)` method when
+ * using the new embedding. The stub satisfies compilation but is
+ * never used at runtime.
+ */
+public interface PluginRegistry {
+    /** Empty registrar interface for legacy plugins. */
+    interface Registrar {
+    }
+}


### PR DESCRIPTION
## Summary
- add minimal stub for `PluginRegistry` to allow legacy plugins to compile

## Testing
- `dart test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687033b3d120832f90aa9756d68156fb