### PR TITLE
Replace file_picker with file_selector

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -361,14 +361,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
-  file_picker:
+  file_selector:
     dependency: "direct main"
     description:
-      name: file_picker
-      sha256: "1bbf65dd997458a08b531042ec3794112a6c39c07c37ff22113d2e7e4f81d4e4"
+      name: file_selector
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.1"
+    version: "1.0.2"
   file_selector_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   equatable: ^2.0.5
   url_launcher: ^6.2.1
   flutter_dotenv: ^5.1.0
-  file_picker: ^6.1.1
+  file_selector: ^1.0.2
   html: ^0.15.4
 
   # UI e Animações

--- a/pubspec_web.yaml
+++ b/pubspec_web.yaml
@@ -36,6 +36,7 @@ dependencies:
   uuid: ^4.2.1
   equatable: ^2.0.5
   flutter_dotenv: ^5.1.0
+  file_selector: ^1.0.2
   # UI e Animações
   lottie: ^2.7.0
   cached_network_image: ^3.3.0


### PR DESCRIPTION
## Summary
- use `file_selector` instead of deprecated `file_picker` in import invoice page
- update dependencies

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700575c0dc832fa2fe78bcc227f467