### PR TITLE
Handle duplicate firebase initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,10 +16,15 @@ void main() async {
 
   await AppConfig.load();
 
-  if (Firebase.apps.isEmpty) {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
+  try {
+    if (Firebase.apps.isEmpty) {
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+    }
+  } on FirebaseException catch (e) {
+    // Ignore duplicate initialization errors caused by hot restarts
+    if (e.code != 'duplicate-app') rethrow;
   }
 
   runApp(


### PR DESCRIPTION
## Summary
- ignore Firebase 'duplicate-app' errors during startup to avoid crashes after hot restarts

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687063d08da4832f96d6619129f04005