### PR TITLE
Implement cached images

### DIFF
--- a/lib/core/utils/cache_manager.dart
+++ b/lib/core/utils/cache_manager.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+import '../constants/app_constants.dart';
+
+class AppCacheManagers {
+  AppCacheManagers._();
+
+  static final BaseCacheManager imageCache = CacheManager(
+    Config(
+      'imageCache',
+      stalePeriod: Duration(days: AppConstants.imageCacheDuration),
+      maxNrOfCacheObjects: 200,
+    ),
+  );
+}

--- a/lib/presentation/pages/admin/add_product_page.dart
+++ b/lib/presentation/pages/admin/add_product_page.dart
@@ -12,6 +12,7 @@ import '../../../core/utils/validators.dart';
 import '../../../core/logging/firebase_logger.dart';
 import '../product/product_search_page.dart';
 import '../../../data/datasources/cosmos_service.dart';
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 
 class AddProductPage extends StatefulWidget {
   const AddProductPage({super.key});
@@ -367,10 +368,9 @@ class _AddProductPageState extends State<AddProductPage> {
               ]
               else if (_imageUrl != null && _imageUrl!.isNotEmpty) ...[
                 const SizedBox(height: AppTheme.paddingMedium),
-                Image.network(
-                  _imageUrl!,
+                AppCachedImage(
+                  imageUrl: _imageUrl!,
                   height: 150,
-                  fit: BoxFit.cover,
                 ),
               ],
               const SizedBox(height: AppTheme.paddingMedium),

--- a/lib/presentation/pages/admin/edit_product_page.dart
+++ b/lib/presentation/pages/admin/edit_product_page.dart
@@ -12,6 +12,7 @@ import '../../../core/utils/validators.dart';
 import '../../../core/logging/firebase_logger.dart';
 import '../product/product_search_page.dart';
 import '../../../data/datasources/cosmos_service.dart';
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 
 class EditProductPage extends StatefulWidget {
   final DocumentSnapshot document;
@@ -431,10 +432,9 @@ class _EditProductPageState extends State<EditProductPage> {
               else if (_imageUrl != null && _imageUrl!.isNotEmpty)
                 ...[
                   const SizedBox(height: AppTheme.paddingMedium),
-                  Image.network(
-                    _imageUrl!,
+                  AppCachedImage(
+                    imageUrl: _imageUrl!,
                     height: 150,
-                    fit: BoxFit.cover,
                   ),
                 ],
               const SizedBox(height: AppTheme.paddingMedium),

--- a/lib/presentation/pages/admin/manage_products_page.dart
+++ b/lib/presentation/pages/admin/manage_products_page.dart
@@ -4,6 +4,7 @@ import '../../../core/themes/app_theme.dart';
 import 'add_product_page.dart';
 import 'edit_product_page.dart';
 import '../../../core/logging/firebase_logger.dart';
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 
 class ManageProductsPage extends StatelessWidget {
   const ManageProductsPage({super.key});
@@ -68,13 +69,13 @@ class ManageProductsPage extends StatelessWidget {
               final doc = docs[index];
               final data = doc.data() as Map<String, dynamic>;
               return ListTile(
-                leading: data['image_url'] != null &&
-                        (data['image_url'] as String).isNotEmpty
-                    ? CircleAvatar(
-                        backgroundImage: NetworkImage(data['image_url']),
-                      )
-                    : const Icon(Icons.shopping_bag,
-                        color: AppTheme.primaryColor),
+                leading: ClipOval(
+                  child: AppCachedImage(
+                    imageUrl: data['image_url'] as String?,
+                    width: 40,
+                    height: 40,
+                  ),
+                ),
                 title: Text(data['name'] ?? ''),
                 subtitle: Text(
                   "${data['brand'] ?? ''} - ${data['barcode'] ?? ''}\n${data['description'] ?? ''}",

--- a/lib/presentation/pages/admin/validate_prices_page.dart
+++ b/lib/presentation/pages/admin/validate_prices_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../../../core/constants/enums.dart';
 import '../../../core/themes/app_theme.dart';
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 
 class ValidatePricesPage extends StatefulWidget {
   const ValidatePricesPage({super.key});
@@ -80,17 +81,11 @@ class _ValidatePricesPageState extends State<ValidatePricesPage> {
               return Card(
                 margin: const EdgeInsets.only(bottom: AppTheme.paddingSmall),
                 child: ListTile(
-                  leading: imageUrl != null && imageUrl.isNotEmpty
-                      ? Image.network(
-                          imageUrl,
-                          width: 56,
-                          height: 56,
-                          fit: BoxFit.cover,
-                        )
-                      : const Icon(
-                          Icons.local_offer,
-                          color: AppTheme.primaryColor,
-                        ),
+                  leading: AppCachedImage(
+                    imageUrl: imageUrl,
+                    width: 56,
+                    height: 56,
+                  ),
                   title: Text(data['product_name'] ?? 'Produto'),
                   subtitle: Text(data['store_name'] ?? 'Comércio'),
                   trailing: Row(

--- a/lib/presentation/pages/feed/feed_page.dart
+++ b/lib/presentation/pages/feed/feed_page.dart
@@ -7,6 +7,7 @@ import '../../../core/utils/formatters.dart';
 import '../../../core/constants/enums.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/shopping_list_provider.dart';
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 import '../price/price_detail_page.dart';
 import '../invoice/invoice_qr_page.dart';
 import '../auth/login_page.dart';
@@ -401,22 +402,15 @@ class _FeedPageState extends ConsumerState<FeedPage> {
                         Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            productImage != null && productImage.isNotEmpty
-                                ? ClipRRect(
-                                    borderRadius:
-                                        BorderRadius.circular(AppTheme.radiusSmall),
-                                    child: Image.network(
-                                      productImage,
-                                      width: 56,
-                                      height: 56,
-                                      fit: BoxFit.cover,
-                                    ),
-                                  )
-                                : const Icon(
-                                    Icons.shopping_bag,
-                                    color: AppTheme.primaryColor,
-                                    size: 56,
-                                  ),
+                            ClipRRect(
+                              borderRadius:
+                                  BorderRadius.circular(AppTheme.radiusSmall),
+                              child: AppCachedImage(
+                                imageUrl: productImage,
+                                width: 56,
+                                height: 56,
+                              ),
+                            ),
                             const SizedBox(width: AppTheme.paddingSmall),
                             Expanded(
                               child: Column(
@@ -427,9 +421,12 @@ class _FeedPageState extends ConsumerState<FeedPage> {
                                   Row(
                                     children: [
                                       if (storeImage != null && storeImage.isNotEmpty)
-                                        CircleAvatar(
-                                          backgroundImage: NetworkImage(storeImage),
-                                          radius: 10,
+                                        ClipOval(
+                                          child: AppCachedImage(
+                                            imageUrl: storeImage,
+                                            width: 20,
+                                            height: 20,
+                                          ),
                                         ),
                                       if (storeImage != null && storeImage.isNotEmpty)
                                         const SizedBox(width: 4),

--- a/lib/presentation/pages/price/price_detail_page.dart
+++ b/lib/presentation/pages/price/price_detail_page.dart
@@ -7,6 +7,7 @@ import 'add_price_page.dart';
 import 'package:share_plus/share_plus.dart';
 import 'dart:io';
 import 'package:http/http.dart' as http;
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 
 class PriceDetailPage extends StatelessWidget {
   final DocumentSnapshot price;
@@ -120,13 +121,11 @@ class PriceDetailPage extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                if (productImage != null && productImage.isNotEmpty)
-                  Image.network(
-                    productImage,
-                    width: double.infinity,
-                    height: 200,
-                    fit: BoxFit.cover,
-                  ),
+                AppCachedImage(
+                  imageUrl: productImage,
+                  width: double.infinity,
+                  height: 200,
+                ),
                 const SizedBox(height: AppTheme.paddingMedium),
                 Text(
                   productName.isNotEmpty ? productName : 'Produto',

--- a/lib/presentation/pages/price/user_prices_page.dart
+++ b/lib/presentation/pages/price/user_prices_page.dart
@@ -7,6 +7,7 @@ import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
 import '../../providers/auth_provider.dart';
 import 'price_detail_page.dart';
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 
 class UserPricesPage extends ConsumerWidget {
   const UserPricesPage({super.key});
@@ -48,9 +49,11 @@ class UserPricesPage extends ConsumerWidget {
               );
               final imageUrl = data['image_url'] as String?;
               return ListTile(
-                leading: imageUrl != null && imageUrl.isNotEmpty
-                    ? Image.network(imageUrl, width: 56, height: 56, fit: BoxFit.cover)
-                    : const Icon(Icons.photo),
+                leading: AppCachedImage(
+                  imageUrl: imageUrl,
+                  width: 56,
+                  height: 56,
+                ),
                 title: Text(data['product_name'] ?? 'Produto'),
                 subtitle: Text('${data['store_name'] ?? 'Comércio'}\n${status.displayName}'),
                 isThreeLine: true,

--- a/lib/presentation/pages/product/product_detail_page.dart
+++ b/lib/presentation/pages/product/product_detail_page.dart
@@ -8,6 +8,7 @@ import '../admin/edit_product_page.dart';
 
 import '../../../data/datasources/cosmos_service.dart';
 import '../../../core/themes/app_theme.dart';
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 
 class ProductDetailPage extends ConsumerWidget {
   final DocumentSnapshot product;
@@ -91,12 +92,10 @@ class ProductDetailPage extends ConsumerWidget {
       ),
       body: ListView(
         children: [
-          if (data['image_url'] != null && (data['image_url'] as String).isNotEmpty)
-            Image.network(
-              data['image_url'],
-              height: 150,
-              fit: BoxFit.cover,
-            ),
+          AppCachedImage(
+            imageUrl: data['image_url'] as String?,
+            height: 150,
+          ),
           Padding(
             padding: const EdgeInsets.all(AppTheme.paddingMedium),
             child: Column(

--- a/lib/presentation/pages/product/product_prices_page.dart
+++ b/lib/presentation/pages/product/product_prices_page.dart
@@ -9,6 +9,7 @@ import '../../providers/store_favorites_provider.dart';
 import '../price/add_price_page.dart';
 import '../price/price_detail_page.dart';
 import 'product_detail_page.dart';
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 
 class ProductPricesPage extends ConsumerStatefulWidget {
   final DocumentSnapshot product;
@@ -62,14 +63,11 @@ class _ProductPricesPageState extends ConsumerState<ProductPricesPage> {
       ),
       body: Column(
         children: [
-          if (data['image_url'] != null &&
-              (data['image_url'] as String).isNotEmpty)
-            Image.network(
-              data['image_url'],
-              width: double.infinity,
-              height: 200,
-              fit: BoxFit.cover,
-            ),
+          AppCachedImage(
+            imageUrl: data['image_url'] as String?,
+            width: double.infinity,
+            height: 200,
+          ),
           Expanded(
             child: StreamBuilder<QuerySnapshot>(
               stream: FirebaseFirestore.instance

--- a/lib/presentation/pages/product/product_search_page.dart
+++ b/lib/presentation/pages/product/product_search_page.dart
@@ -6,6 +6,7 @@ import '../../../core/themes/app_theme.dart';
 import '../admin/add_product_page.dart';
 import '../product/product_prices_page.dart';
 import '../../providers/auth_provider.dart';
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 class ProductSearchPage extends ConsumerStatefulWidget {
   final ValueChanged<DocumentSnapshot>? onSelected;
   const ProductSearchPage({this.onSelected, super.key});
@@ -142,23 +143,15 @@ class _ProductSearchPageState extends ConsumerState<ProductSearchPage> {
                                   crossAxisAlignment: CrossAxisAlignment.center,
                                   children: [
                                     Expanded(
-                                      child: data['image_url'] != null &&
-                                              (data['image_url'] as String)
-                                                  .isNotEmpty
-                                          ? ClipRRect(
-                                              borderRadius: BorderRadius.circular(
-                                                  AppTheme.radiusSmall),
-                                              child: Image.network(
-                                                data['image_url'],
-                                                fit: BoxFit.cover,
-                                                width: double.infinity,
-                                              ),
-                                            )
-                                          : const Icon(
-                                              Icons.shopping_bag,
-                                              size: 40,
-                                              color: AppTheme.primaryColor,
-                                            ),
+                                      child: ClipRRect(
+                                        borderRadius: BorderRadius.circular(
+                                            AppTheme.radiusSmall),
+                                        child: AppCachedImage(
+                                          imageUrl: data['image_url'] as String?,
+                                          width: double.infinity,
+                                          fit: BoxFit.cover,
+                                        ),
+                                      ),
                                     ),
                                     const SizedBox(
                                         height: AppTheme.paddingSmall),

--- a/lib/presentation/pages/store/store_detail_page.dart
+++ b/lib/presentation/pages/store/store_detail_page.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/constants/app_constants.dart';
 import '../../providers/store_favorites_provider.dart';
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 // Página de detalhes exibe apenas informações do comércio.
 
 class StoreDetailPage extends ConsumerWidget {
@@ -36,11 +37,11 @@ class StoreDetailPage extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (data['latitude'] != null && data['longitude'] != null)
-            Image.network(
-              'https://maps.googleapis.com/maps/api/staticmap?center=${data['latitude']},${data['longitude']}&zoom=16&size=600x200&markers=color:red%7C${data['latitude']},${data['longitude']}&key=${AppConstants.googleMapsApiKey}',
+            AppCachedImage(
+              imageUrl:
+                  'https://maps.googleapis.com/maps/api/staticmap?center=${data['latitude']},${data['longitude']}&zoom=16&size=600x200&markers=color:red%7C${data['latitude']},${data['longitude']}&key=${AppConstants.googleMapsApiKey}',
               width: double.infinity,
               height: 200,
-              fit: BoxFit.cover,
             ),
           Padding(
             padding: const EdgeInsets.all(AppTheme.paddingMedium),

--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -9,6 +9,7 @@ import '../../providers/store_favorites_provider.dart';
 import '../price/add_price_page.dart';
 import '../price/price_detail_page.dart';
 import 'store_detail_page.dart';
+import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 
 class StorePricesPage extends ConsumerStatefulWidget {
   final DocumentSnapshot store;
@@ -203,20 +204,14 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                     }
 
                     return ListTile(
-                      leading: imageUrl != null && imageUrl.isNotEmpty
-                          ? ClipRRect(
-                              borderRadius: BorderRadius.circular(AppTheme.radiusSmall),
-                              child: Image.network(
-                                imageUrl,
-                                width: 56,
-                                height: 56,
-                                fit: BoxFit.cover,
-                              ),
-                            )
-                          : const Icon(
-                              Icons.shopping_bag,
-                              color: AppTheme.primaryColor,
-                            ),
+                      leading: ClipRRect(
+                        borderRadius: BorderRadius.circular(AppTheme.radiusSmall),
+                        child: AppCachedImage(
+                          imageUrl: imageUrl,
+                          width: 56,
+                          height: 56,
+                        ),
+                      ),
                       title: Text(label),
                       trailing: Column(
                         mainAxisSize: MainAxisSize.min,

--- a/lib/presentation/widgets/app_cached_image.dart
+++ b/lib/presentation/widgets/app_cached_image.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+
+import '../../core/utils/cache_manager.dart';
+
+class AppCachedImage extends StatelessWidget {
+  final String? imageUrl;
+  final double? width;
+  final double? height;
+  final BoxFit fit;
+  final BorderRadius? borderRadius;
+
+  const AppCachedImage({
+    super.key,
+    required this.imageUrl,
+    this.width,
+    this.height,
+    this.fit = BoxFit.cover,
+    this.borderRadius,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final placeholder = Image.asset(
+      'assets/icons/app_icon.png',
+      width: width,
+      height: height,
+      fit: BoxFit.contain,
+    );
+
+    if (imageUrl == null || imageUrl!.isEmpty) {
+      return _wrap(placeholder);
+    }
+
+    final img = CachedNetworkImage(
+      imageUrl: imageUrl!,
+      cacheManager: AppCacheManagers.imageCache,
+      width: width,
+      height: height,
+      fit: fit,
+      placeholder: (context, url) => placeholder,
+      errorWidget: (context, url, error) => placeholder,
+    );
+
+    return _wrap(img);
+  }
+
+  Widget _wrap(Widget child) {
+    if (borderRadius != null) {
+      return ClipRRect(
+        borderRadius: borderRadius!,
+        child: child,
+      );
+    }
+    return child;
+  }
+}


### PR DESCRIPTION
## Summary
- add `AppCacheManagers` helper
- add `AppCachedImage` widget for cached images with placeholder
- use `AppCachedImage` across pages to cache product images and show default image when loading fails

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter test integration_test/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870cbad33d0832fabdf9bc1f4f51f68