### PR TITLE
Add invoice store selection

### DIFF
--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -149,6 +149,7 @@ class InvoiceImportService {
     required String series,
     required String number,
     required String userId,
+    String? storeId,
   }) async {
     final existing = await _firestore
         .collection('invoices')
@@ -156,7 +157,14 @@ class InvoiceImportService {
         .limit(1)
         .get();
     if (existing.docs.isNotEmpty) {
-      return existing.docs.first.reference;
+      final ref = existing.docs.first.reference;
+      if (storeId != null) {
+        final data = existing.docs.first.data();
+        if (!(data.containsKey('store_id'))) {
+          await ref.update({'store_id': storeId});
+        }
+      }
+      return ref;
     }
 
     final data = {
@@ -168,6 +176,7 @@ class InvoiceImportService {
       'number': number,
       'created_at': Timestamp.now(),
       'status': ModerationStatus.underReview.value,
+      if (storeId != null) 'store_id': storeId,
     };
     final doc = await _firestore.collection('invoices').add(data);
     return doc;

--- a/lib/data/datasources/invoice_service.dart
+++ b/lib/data/datasources/invoice_service.dart
@@ -15,6 +15,7 @@ class InvoiceService {
     required String series,
     required String number,
     required String userId,
+    String? storeId,
   }) async {
     final existing = await _firestore
         .collection('invoices')
@@ -34,6 +35,7 @@ class InvoiceService {
       'number': number,
       'created_at': Timestamp.now(),
       'status': ModerationStatus.underReview.value,
+      if (storeId != null) 'store_id': storeId,
     };
     FirebaseLogger.log('submitInvoice', data);
     await _firestore.collection('invoices').add(data);


### PR DESCRIPTION
## Summary
- add optional `storeId` to `InvoiceService` and `InvoiceImportService`
- reuse existing store when importing invoice
- prompt user to select a place when scanning a new invoice
- create store for selected place and link invoice to it

## Testing
- `dart` formatter not available so formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_6870d57ce358832fbb4c42575c024f7c