### PR TITLE
Default volume for non-ean products

### DIFF
--- a/lib/presentation/pages/admin/add_product_page.dart
+++ b/lib/presentation/pages/admin/add_product_page.dart
@@ -167,6 +167,12 @@ class _AddProductPageState extends State<AddProductPage> {
   }
 
   Future<void> _submit() async {
+    if (_barcodeController.text.trim().isEmpty) {
+      if (_volumeController.text.trim().isEmpty) {
+        _volumeController.text = '1';
+      }
+      _unit ??= 'kg';
+    }
     if (_formKey.currentState!.validate()) {
       try {
         String? imageUrl = _imageUrl;


### PR DESCRIPTION
## Summary
- set default volume and unit if a product is created without an EAN code

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870d4c564b4832f8947f654d5ac0122