### PR TITLE
Add env api key logging

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -1,8 +1,28 @@
 import 'dart:io' show File, Platform;
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, debugPrint;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class AppConfig {
+  static const List<String> _apiKeys = [
+    'GOOGLE_MAPS_API_KEY_ANDROID',
+    'GOOGLE_MAPS_API_KEY_IOS',
+    'GOOGLE_MAPS_API_KEY_WEB',
+    'GOOGLE_MAPS_API_KEY',
+    'GOOGLE_SIGNIN_CLIENT_ID',
+    'FIREBASE_WEB_API_KEY',
+    'FIREBASE_WEB_APP_ID',
+    'FIREBASE_WEB_MESSAGING_SENDER_ID',
+    'FIREBASE_WEB_AUTH_DOMAIN',
+    'FIREBASE_PROJECT_ID',
+    'FIREBASE_STORAGE_BUCKET',
+    'FIREBASE_MEASUREMENT_ID',
+    'FIREBASE_ANDROID_API_KEY',
+    'FIREBASE_ANDROID_APP_ID',
+    'FIREBASE_IOS_API_KEY',
+    'FIREBASE_IOS_APP_ID',
+    'COSMOS_TOKEN',
+  ];
+
   static Future<void> load({String fileName = '.env'}) async {
     if (kIsWeb) {
       try {
@@ -10,11 +30,25 @@ class AppConfig {
       } catch (_) {
         // In web builds the file may not be available, ignore errors
       }
+      _logLoadedApiKeys();
       return;
     }
 
     if (await File(fileName).exists()) {
       await dotenv.load(fileName: fileName);
+    }
+    _logLoadedApiKeys();
+  }
+
+  static void _logLoadedApiKeys() {
+    if (!dotenv.isInitialized) return;
+    for (final key in _apiKeys) {
+      final value = dotenv.env[key];
+      if (value != null && value.isNotEmpty) {
+        debugPrint('[CONFIG] $key: $value');
+      } else {
+        debugPrint('[CONFIG] $key not found or empty');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- show which API keys were loaded from the `.env`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687115d47d64832fa43b7425a3717664