### PR TITLE
Ensure Google Maps API key initialization

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -40,6 +40,11 @@ class AppConstants {
           key = AppConfig.get('GOOGLE_MAPS_API_KEY');
       }
     }
+    assert(
+      key.isNotEmpty,
+      'Google Maps API key not configured for $platform. '
+      'Ensure AppConfig.load() has been called and the key is set.',
+    );
     MapsLogger.log('googleMapsApiKey_loaded', {
       'platform': platform,
       'keySnippet': key.isNotEmpty ? key.substring(0, 5) + '...' : 'EMPTY',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,11 +10,17 @@ import 'presentation/providers/auth_provider.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 import 'core/config/app_config.dart';
+import 'core/constants/app_constants.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await AppConfig.load();
+
+  assert(
+    AppConstants.googleMapsApiKey.isNotEmpty,
+    'Google Maps API key must be provided. Check your environment configuration.',
+  );
 
   try {
     if (Firebase.apps.isEmpty) {

--- a/web/index.html
+++ b/web/index.html
@@ -56,8 +56,12 @@
   <script src="flutter.js" defer=""></script>
   <script id="google-maps" src=""></script>
   <script>
-    document.getElementById('google-maps').src =
-      `https://maps.googleapis.com/maps/api/js?key=${window.env.GOOGLE_MAPS_API_KEY_WEB}&libraries=places`;
+    if (window.env && window.env.GOOGLE_MAPS_API_KEY_WEB) {
+      document.getElementById('google-maps').src =
+        `https://maps.googleapis.com/maps/api/js?key=${window.env.GOOGLE_MAPS_API_KEY_WEB}&libraries=places`;
+    } else {
+      console.error('GOOGLE_MAPS_API_KEY_WEB not configured');
+    }
     window.searchPlaces = function(query, lat, lng, radius) {
       return new Promise(function(resolve, reject) {
         const service = new google.maps.places.PlacesService(document.createElement('div'));


### PR DESCRIPTION
## Summary
- assert that Google Maps API key exists before usage
- validate API key in `main.dart`
- check web environment key before loading Maps script

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712b9b6928832f8b8d5a19c5b74706