### PR TITLE
Add assert to ensure .env initialized for Maps API

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -3,6 +3,7 @@ import '../config/app_config.dart';
 import 'package:flutter/foundation.dart' show kIsWeb, defaultTargetPlatform, TargetPlatform;
 import '../logging/maps_logger.dart';
 import '../../maps_options.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class AppConstants {
   // Configurações gerais
@@ -13,6 +14,10 @@ class AppConstants {
   static const String baseUrl = 'https://api.precinho.com';
   static const int timeoutDuration = 30000; // 30 segundos
   static String get googleMapsApiKey {
+    assert(
+      dotenv.isInitialized,
+      '.env not loaded. Call AppConfig.load() before using the Maps API.',
+    );
     String platform;
     String key;
     if (kIsWeb) {


### PR DESCRIPTION
## Summary
- import `flutter_dotenv` in `AppConstants`
- assert that `.env` is loaded before returning `googleMapsApiKey`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68723ba9e5a8832fbdb3b777d8ccdd7e