### PR TITLE
Simplify shopping list into price checklist

### DIFF
--- a/lib/presentation/pages/shopping_list/shopping_lists_page.dart
+++ b/lib/presentation/pages/shopping_list/shopping_lists_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../providers/shopping_list_provider.dart';
-import 'shopping_list_detail_page.dart';
+import 'shopping_price_list_page.dart';
 
 class ShoppingListsPage extends ConsumerWidget {
   const ShoppingListsPage({super.key});
@@ -37,7 +37,7 @@ class ShoppingListsPage extends ConsumerWidget {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (_) => ShoppingListDetailPage(listId: list.id),
+                          builder: (_) => ShoppingPriceListPage(listId: list.id),
                         ),
                       );
                     },
@@ -91,7 +91,7 @@ class ShoppingListsPage extends ConsumerWidget {
       Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (_) => ShoppingListDetailPage(listId: id),
+          builder: (_) => ShoppingPriceListPage(listId: id),
         ),
       );
     }

--- a/lib/presentation/pages/shopping_list/shopping_price_list_page.dart
+++ b/lib/presentation/pages/shopping_list/shopping_price_list_page.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/themes/app_theme.dart';
+import '../../../core/utils/formatters.dart';
+import '../../providers/shopping_list_provider.dart';
+
+class ShoppingPriceListPage extends ConsumerWidget {
+  final String listId;
+  const ShoppingPriceListPage({required this.listId, super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final list =
+        ref.watch(shoppingListProvider).firstWhere((l) => l.id == listId);
+
+    final Map<String, List<ShoppingListItem>> groups = {};
+    for (final item in list.items) {
+      final store = item.storeName ?? 'Comércio';
+      groups.putIfAbsent(store, () => []).add(item);
+    }
+    final stores = groups.keys.toList();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(list.name),
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(AppTheme.paddingMedium),
+        itemCount: stores.length,
+        itemBuilder: (context, index) {
+          final store = stores[index];
+          final items = groups[store]!;
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding:
+                    const EdgeInsets.only(bottom: AppTheme.paddingSmall),
+                child: Text(
+                  store,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
+              ...items.map((item) {
+                return Container(
+                  decoration: BoxDecoration(
+                    border: Border(
+                      bottom: BorderSide(color: Colors.grey.shade300),
+                    ),
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                      vertical: AppTheme.paddingSmall),
+                  child: Row(
+                    children: [
+                      Checkbox(
+                        value: item.isCompleted,
+                        onChanged: (_) {
+                          ref
+                              .read(shoppingListProvider.notifier)
+                              .toggleItemCompleted(
+                                listId: listId,
+                                itemId: item.id,
+                              );
+                        },
+                      ),
+                      Expanded(child: Text(item.productName)),
+                      Opacity(
+                        opacity: item.isCompleted ? 0.5 : 1.0,
+                        child: Text(
+                          item.price != null
+                              ? Formatters.formatPrice(item.price!)
+                              : '-',
+                          style: AppTheme.priceTextStyle,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }),
+              const SizedBox(height: AppTheme.paddingMedium),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/providers/shopping_list_provider.dart
+++ b/lib/presentation/providers/shopping_list_provider.dart
@@ -131,6 +131,29 @@ class ShoppingListNotifier extends StateNotifier<List<ShoppingList>> {
     _storage.saveLists(state.map((e) => ShoppingListModel.fromEntity(e)).toList());
   }
 
+  void toggleItemCompleted({required String listId, required String itemId}) {
+    state = [
+      for (final l in state)
+        if (l.id == listId)
+          l.copyWith(
+            items: [
+              for (final item in l.items)
+                if (item.id == itemId)
+                  item.copyWith(
+                    isCompleted: !item.isCompleted,
+                    updatedAt: DateTime.now(),
+                  )
+                else
+                  item,
+            ],
+            updatedAt: DateTime.now(),
+          )
+        else
+          l
+    ];
+    _storage.saveLists(state.map((e) => ShoppingListModel.fromEntity(e)).toList());
+  }
+
   void clearPrices(String listId) {
     state = [
       for (final l in state)

--- a/test/shopping_list_provider_test.dart
+++ b/test/shopping_list_provider_test.dart
@@ -75,4 +75,32 @@ void main() {
     expect(list.items.first.storeId, isNull);
     expect(list.items.first.storeName, isNull);
   });
+
+  test('toggle item completed', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(shoppingListProvider.notifier);
+    final listId = notifier.createList('Teste');
+    notifier.addProductToList(
+      listId: listId,
+      productId: '1',
+      productName: 'Banana',
+      quantity: 1,
+    );
+
+    final itemId = container
+        .read(shoppingListProvider)
+        .firstWhere((l) => l.id == listId)
+        .items
+        .first
+        .id;
+
+    notifier.toggleItemCompleted(listId: listId, itemId: itemId);
+    var list = container.read(shoppingListProvider).firstWhere((l) => l.id == listId);
+    expect(list.items.first.isCompleted, isTrue);
+
+    notifier.toggleItemCompleted(listId: listId, itemId: itemId);
+    list = container.read(shoppingListProvider).firstWhere((l) => l.id == listId);
+    expect(list.items.first.isCompleted, isFalse);
+  });
 }


### PR DESCRIPTION
## Summary
- create `ShoppingPriceListPage` to show prices grouped by store with checkboxes
- allow toggling completion state via `toggleItemCompleted`
- update provider tests for new behaviour
- navigate to `ShoppingPriceListPage` when opening a list

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872cecd2ae0832fa698f0a6587b0880