### PR TITLE
Fix missing import for ShoppingListItem

### DIFF
--- a/lib/presentation/pages/shopping_list/shopping_price_list_page.dart
+++ b/lib/presentation/pages/shopping_list/shopping_price_list_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
 import '../../providers/shopping_list_provider.dart';
+import '../../../domain/entities/shopping_list.dart';
 
 class ShoppingPriceListPage extends ConsumerWidget {
   final String listId;


### PR DESCRIPTION
## Summary
- import ShoppingListItem definition so analyzer recognizes it

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872f6109334832f8457cdd5f2562876