### PR TITLE
Adiciona estatística de comércio descobertos no perfil

### DIFF
--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -19,13 +19,20 @@ Future<Map<String, int>> _fetchUserStats(String userId) async {
       .where('user_id', isEqualTo: userId)
       .count()
       .get();
+  final storeAgg = await FirebaseFirestore.instance
+      .collection('stores')
+      .where('user_id', isEqualTo: userId)
+      .count()
+      .get();
 
   final priceCount = priceAgg.count ?? 0;
   final invoiceCount = invoiceAgg.count ?? 0;
+  final storeCount = storeAgg.count ?? 0;
 
   return {
     'prices': priceCount,
     'invoices': invoiceCount,
+    'stores': storeCount,
   };
 }
 
@@ -155,6 +162,7 @@ class ProfilePage extends ConsumerWidget {
       builder: (context, snapshot) {
         final priceCount = snapshot.data?['prices'];
         final invoiceCount = snapshot.data?['invoices'];
+        final storeCount = snapshot.data?['stores'];
 
         return Card(
           child: Padding(
@@ -200,6 +208,14 @@ class ProfilePage extends ConsumerWidget {
                             ),
                           );
                         },
+                      ),
+                    ),
+                    Expanded(
+                      child: _buildStatItem(
+                        context,
+                        'Comércio descobertos',
+                        storeCount != null ? '$storeCount' : '...',
+                        Icons.store,
                       ),
                     ),
                   ],


### PR DESCRIPTION
## Summary
- adiciona consulta aos comércios cadastrados pelo usuário
- exibe a contagem como "Comércio descobertos" na seção de estatísticas

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687310055434832f95f0356232bb2a3c