### PR TITLE
Add user link to store codes and show discovery stats

### DIFF
--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -41,6 +41,7 @@ class InvoiceImportService {
     DocumentReference<Map<String, dynamic>>? storeRef,
     String? storeCode,
     String? storeDescription,
+    String? userId,
   }) async {
     // Primeiro tenta encontrar pelo c\u00f3digo vinculado ao com\u00e9rcio
     if (storeRef != null && storeCode != null && storeCode.isNotEmpty) {
@@ -93,6 +94,7 @@ class InvoiceImportService {
           'product_id': productRef.id,
           'code': storeCode,
           'description': storeDescription ?? name,
+          if (userId != null) 'user_id': userId,
           if (ncm != null) 'ncm_code': ncm,
           if (ean != null) 'ean_code': ean,
           'created_at': Timestamp.now(),

--- a/lib/data/parsers/invoice_html_parser.dart
+++ b/lib/data/parsers/invoice_html_parser.dart
@@ -229,6 +229,7 @@ class InvoiceHtmlParser {
         storeRef: storeRef,
         storeCode: codigo,
         storeDescription: descricao,
+        userId: userId,
       );
 
       await service.createPrice(

--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -24,15 +24,22 @@ Future<Map<String, int>> _fetchUserStats(String userId) async {
       .where('user_id', isEqualTo: userId)
       .count()
       .get();
+  final storeProductAgg = await FirebaseFirestore.instance
+      .collection('store_products')
+      .where('user_id', isEqualTo: userId)
+      .count()
+      .get();
 
   final priceCount = priceAgg.count ?? 0;
   final invoiceCount = invoiceAgg.count ?? 0;
   final storeCount = storeAgg.count ?? 0;
+  final storeProductCount = storeProductAgg.count ?? 0;
 
   return {
     'prices': priceCount,
     'invoices': invoiceCount,
     'stores': storeCount,
+    'storeProducts': storeProductCount,
   };
 }
 
@@ -163,6 +170,7 @@ class ProfilePage extends ConsumerWidget {
         final priceCount = snapshot.data?['prices'];
         final invoiceCount = snapshot.data?['invoices'];
         final storeCount = snapshot.data?['stores'];
+        final storeProductCount = snapshot.data?['storeProducts'];
 
         return Card(
           child: Padding(
@@ -210,12 +218,24 @@ class ProfilePage extends ConsumerWidget {
                         },
                       ),
                     ),
+                  ],
+                ),
+                Row(
+                  children: [
                     Expanded(
                       child: _buildStatItem(
                         context,
                         'Comércio descobertos',
                         storeCount != null ? '$storeCount' : '...',
                         Icons.store,
+                      ),
+                    ),
+                    Expanded(
+                      child: _buildStatItem(
+                        context,
+                        'Produtos descobertos',
+                        storeProductCount != null ? '$storeProductCount' : '...',
+                        Icons.shopping_bag,
                       ),
                     ),
                   ],


### PR DESCRIPTION
## Summary
- attach invoice user to store code records when importing prices
- count store codes in profile stats and show as "Produtos descobertos"

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687311c325c4832fb0a58c6454881c38