### PR TITLE
Enable deletion of shopping lists and marked items

### DIFF
--- a/lib/presentation/pages/shopping_list/shopping_lists_page.dart
+++ b/lib/presentation/pages/shopping_list/shopping_lists_page.dart
@@ -43,7 +43,16 @@ class ShoppingListsPage extends ConsumerWidget {
                     },
                     title: Text(list.name),
                     subtitle: LinearProgressIndicator(value: progress),
-                    trailing: Text('$completed/$total'),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text('$completed/$total'),
+                        IconButton(
+                          icon: const Icon(Icons.delete, color: AppTheme.errorColor),
+                          onPressed: () => _deleteList(context, ref, list.id),
+                        ),
+                      ],
+                    ),
                   ),
                 );
               },
@@ -94,6 +103,31 @@ class ShoppingListsPage extends ConsumerWidget {
           builder: (_) => ShoppingPriceListPage(listId: id),
         ),
       );
+    }
+  }
+
+  Future<void> _deleteList(
+      BuildContext context, WidgetRef ref, String listId) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Excluir Lista'),
+        content: const Text('Tem certeza que deseja excluir esta lista?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Excluir'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true) {
+      ref.read(shoppingListProvider.notifier).deleteList(listId);
     }
   }
 }

--- a/lib/presentation/pages/shopping_list/shopping_price_list_page.dart
+++ b/lib/presentation/pages/shopping_list/shopping_price_list_page.dart
@@ -75,6 +75,14 @@ class ShoppingPriceListPage extends ConsumerWidget {
                           style: AppTheme.priceTextStyle,
                         ),
                       ),
+                      if (item.isCompleted)
+                        IconButton(
+                          icon:
+                              const Icon(Icons.delete, color: AppTheme.errorColor),
+                          onPressed: () => ref
+                              .read(shoppingListProvider.notifier)
+                              .removeItem(listId: listId, itemId: item.id),
+                        ),
                     ],
                   ),
                 );

--- a/lib/presentation/providers/shopping_list_provider.dart
+++ b/lib/presentation/providers/shopping_list_provider.dart
@@ -154,6 +154,28 @@ class ShoppingListNotifier extends StateNotifier<List<ShoppingList>> {
     _storage.saveLists(state.map((e) => ShoppingListModel.fromEntity(e)).toList());
   }
 
+  void removeItem({required String listId, required String itemId}) {
+    state = [
+      for (final l in state)
+        if (l.id == listId)
+          l.copyWith(
+            items: [
+              for (final item in l.items)
+                if (item.id != itemId) item,
+            ],
+            updatedAt: DateTime.now(),
+          )
+        else
+          l
+    ];
+    _storage.saveLists(state.map((e) => ShoppingListModel.fromEntity(e)).toList());
+  }
+
+  void deleteList(String listId) {
+    state = state.where((l) => l.id != listId).toList();
+    _storage.saveLists(state.map((e) => ShoppingListModel.fromEntity(e)).toList());
+  }
+
   void clearPrices(String listId) {
     state = [
       for (final l in state)

--- a/test/shopping_list_provider_test.dart
+++ b/test/shopping_list_provider_test.dart
@@ -103,4 +103,34 @@ void main() {
     list = container.read(shoppingListProvider).firstWhere((l) => l.id == listId);
     expect(list.items.first.isCompleted, isFalse);
   });
+
+  test('remove item and delete list', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(shoppingListProvider.notifier);
+    final first = notifier.createList('L1');
+    final second = notifier.createList('L2');
+    notifier.addProductToList(
+      listId: first,
+      productId: '1',
+      productName: 'Banana',
+      quantity: 1,
+    );
+
+    final itemId = container
+        .read(shoppingListProvider)
+        .firstWhere((l) => l.id == first)
+        .items
+        .first
+        .id;
+
+    notifier.removeItem(listId: first, itemId: itemId);
+    var list = container.read(shoppingListProvider).firstWhere((l) => l.id == first);
+    expect(list.items, isEmpty);
+
+    notifier.deleteList(first);
+    final lists = container.read(shoppingListProvider);
+    expect(lists.length, 1);
+    expect(lists.first.id, second);
+  });
 }


### PR DESCRIPTION
## Summary
- add provider methods to remove items and delete lists
- display delete button for each list
- allow removing completed items directly from the price list view
- test new provider methods

## Testing
- `flutter test test/shopping_list_provider_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687436cae1e8832fa296da109337da62