### PR TITLE
Remove hardcoded API keys

### DIFF
--- a/lib/data/datasources/places_service_io.dart
+++ b/lib/data/datasources/places_service_io.dart
@@ -13,8 +13,8 @@ class PlacesService {
   PlacesService({http.Client? client}) : _client = client ?? http.Client();
 
   String buildPhotoUrl(String photoReference, {int maxWidth = 600}) {
-    //final url = 'https://maps.googleapis.com/maps/api/place/photo?maxwidth=$maxWidth&photo_reference=$photoReference&key=${AppConstants.googleMapsApiKey}';
-	final url = 'https://maps.googleapis.com/maps/api/place/photo?maxwidth=$maxWidth&photo_reference=$photoReference&key=AIzaSyC2Q0duKwqkHEyGlIH6nGe-_ae6qXgb43Y';
+    final url =
+        'https://maps.googleapis.com/maps/api/place/photo?maxwidth=$maxWidth&photo_reference=$photoReference&key=${AppConstants.googleMapsApiKey}';
 
     MapsLogger.log('buildPhotoUrl', {'url': url});
     return url;

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -43,76 +43,76 @@ class DefaultFirebaseOptions {
 
   static FirebaseOptions get web => FirebaseOptions(
         apiKey: AppConfig.get('FIREBASE_WEB_API_KEY',
-            defaultValue: 'AIzaSyDR42GFH7gszEWMOfzmLWmOYatvBBYj-B0'),
+            defaultValue: 'YOUR_FIREBASE_WEB_API_KEY'),
         appId: AppConfig.get('FIREBASE_WEB_APP_ID',
-            defaultValue: '1:827176675042:web:c132fef088db2bd7e9a0bb'),
+            defaultValue: 'YOUR_FIREBASE_WEB_APP_ID'),
         messagingSenderId: AppConfig.get('FIREBASE_WEB_MESSAGING_SENDER_ID',
-            defaultValue: '827176675042'),
+            defaultValue: 'YOUR_FIREBASE_WEB_MESSAGING_SENDER_ID'),
         projectId:
-            AppConfig.get('FIREBASE_PROJECT_ID', defaultValue: 'precinho-dd1c9'),
+            AppConfig.get('FIREBASE_PROJECT_ID', defaultValue: 'YOUR_FIREBASE_PROJECT_ID'),
         authDomain: AppConfig.get('FIREBASE_WEB_AUTH_DOMAIN',
-            defaultValue: 'precinho-dd1c9.firebaseapp.com'),
+            defaultValue: 'YOUR_FIREBASE_WEB_AUTH_DOMAIN'),
         storageBucket: AppConfig.get('FIREBASE_STORAGE_BUCKET',
-            defaultValue: 'precinho-dd1c9.firebasestorage.app'),
+            defaultValue: 'YOUR_FIREBASE_STORAGE_BUCKET'),
         measurementId: AppConfig.get('FIREBASE_MEASUREMENT_ID',
-            defaultValue: 'G-LDPX19149Y'),
+            defaultValue: 'YOUR_MEASUREMENT_ID'),
       );
 
   static FirebaseOptions get android => FirebaseOptions(
         apiKey: AppConfig.get('FIREBASE_ANDROID_API_KEY',
-            defaultValue: 'AIzaSyC2aCiUIpAmvlEXk24HIj1JqiA4ksPpQXg'),
+            defaultValue: 'YOUR_FIREBASE_ANDROID_API_KEY'),
         appId: AppConfig.get('FIREBASE_ANDROID_APP_ID',
-            defaultValue: '1:827176675042:android:00781a4ec7162b73e9a0bb'),
+            defaultValue: 'YOUR_FIREBASE_ANDROID_APP_ID'),
         messagingSenderId: AppConfig.get('FIREBASE_ANDROID_MESSAGING_SENDER_ID',
-            defaultValue: '827176675042'),
+            defaultValue: 'YOUR_FIREBASE_ANDROID_MESSAGING_SENDER_ID'),
         projectId:
-            AppConfig.get('FIREBASE_PROJECT_ID', defaultValue: 'precinho-dd1c9'),
+            AppConfig.get('FIREBASE_PROJECT_ID', defaultValue: 'YOUR_FIREBASE_PROJECT_ID'),
         storageBucket: AppConfig.get('FIREBASE_STORAGE_BUCKET',
-            defaultValue: 'precinho-dd1c9.firebasestorage.app'),
+            defaultValue: 'YOUR_FIREBASE_STORAGE_BUCKET'),
       );
 
   static FirebaseOptions get ios => FirebaseOptions(
         apiKey: AppConfig.get('FIREBASE_IOS_API_KEY',
-            defaultValue: 'AIzaSyBlxQ7-LvkV8cNUIlE3chU7ziBclKc7XMs'),
+            defaultValue: 'YOUR_FIREBASE_IOS_API_KEY'),
         appId: AppConfig.get('FIREBASE_IOS_APP_ID',
-            defaultValue: '1:827176675042:ios:278a838c2e9fdff0e9a0bb'),
+            defaultValue: 'YOUR_FIREBASE_IOS_APP_ID'),
         messagingSenderId: AppConfig.get('FIREBASE_IOS_MESSAGING_SENDER_ID',
-            defaultValue: '827176675042'),
+            defaultValue: 'YOUR_FIREBASE_IOS_MESSAGING_SENDER_ID'),
         projectId:
-            AppConfig.get('FIREBASE_PROJECT_ID', defaultValue: 'precinho-dd1c9'),
+            AppConfig.get('FIREBASE_PROJECT_ID', defaultValue: 'YOUR_FIREBASE_PROJECT_ID'),
         storageBucket: AppConfig.get('FIREBASE_STORAGE_BUCKET',
-            defaultValue: 'precinho-dd1c9.firebasestorage.app'),
+            defaultValue: 'YOUR_FIREBASE_STORAGE_BUCKET'),
         iosBundleId: 'com.precinho.precinhoApp',
       );
 
   static FirebaseOptions get macos => FirebaseOptions(
         apiKey: AppConfig.get('FIREBASE_IOS_API_KEY',
-            defaultValue: 'AIzaSyBlxQ7-LvkV8cNUIlE3chU7ziBclKc7XMs'),
+            defaultValue: 'YOUR_FIREBASE_IOS_API_KEY'),
         appId: AppConfig.get('FIREBASE_IOS_APP_ID',
-            defaultValue: '1:827176675042:ios:278a838c2e9fdff0e9a0bb'),
+            defaultValue: 'YOUR_FIREBASE_IOS_APP_ID'),
         messagingSenderId: AppConfig.get('FIREBASE_IOS_MESSAGING_SENDER_ID',
-            defaultValue: '827176675042'),
+            defaultValue: 'YOUR_FIREBASE_IOS_MESSAGING_SENDER_ID'),
         projectId:
-            AppConfig.get('FIREBASE_PROJECT_ID', defaultValue: 'precinho-dd1c9'),
+            AppConfig.get('FIREBASE_PROJECT_ID', defaultValue: 'YOUR_FIREBASE_PROJECT_ID'),
         storageBucket: AppConfig.get('FIREBASE_STORAGE_BUCKET',
-            defaultValue: 'precinho-dd1c9.firebasestorage.app'),
+            defaultValue: 'YOUR_FIREBASE_STORAGE_BUCKET'),
         iosBundleId: 'com.precinho.precinhoApp',
       );
 
   static FirebaseOptions get windows => FirebaseOptions(
         apiKey: AppConfig.get('FIREBASE_WEB_API_KEY',
-            defaultValue: 'AIzaSyDR42GFH7gszEWMOfzmLWmOYatvBBYj-B0'),
+            defaultValue: 'YOUR_FIREBASE_WEB_API_KEY'),
         appId: AppConfig.get('FIREBASE_WEB_APP_ID',
-            defaultValue: '1:827176675042:web:8bc7d1410ddaa855e9a0bb'),
+            defaultValue: 'YOUR_FIREBASE_WEB_APP_ID'),
         messagingSenderId: AppConfig.get('FIREBASE_WEB_MESSAGING_SENDER_ID',
-            defaultValue: '827176675042'),
+            defaultValue: 'YOUR_FIREBASE_WEB_MESSAGING_SENDER_ID'),
         projectId:
-            AppConfig.get('FIREBASE_PROJECT_ID', defaultValue: 'precinho-dd1c9'),
+            AppConfig.get('FIREBASE_PROJECT_ID', defaultValue: 'YOUR_FIREBASE_PROJECT_ID'),
         authDomain: AppConfig.get('FIREBASE_WEB_AUTH_DOMAIN',
-            defaultValue: 'precinho-dd1c9.firebaseapp.com'),
+            defaultValue: 'YOUR_FIREBASE_WEB_AUTH_DOMAIN'),
         storageBucket: AppConfig.get('FIREBASE_STORAGE_BUCKET',
-            defaultValue: 'precinho-dd1c9.firebasestorage.app'),
+            defaultValue: 'YOUR_FIREBASE_STORAGE_BUCKET'),
         measurementId: AppConfig.get('FIREBASE_MEASUREMENT_ID',
-            defaultValue: 'G-93NLEPJF1D'),
+            defaultValue: 'YOUR_MEASUREMENT_ID'),
       );
 }

--- a/lib/maps_options.dart
+++ b/lib/maps_options.dart
@@ -1,8 +1,8 @@
 // Fallback Google Maps API keys used when environment variables are not provided.
 // Replace these with your own keys if needed.
 class DefaultMapsOptions {
-  static const String web = 'AIzaSyBu348l1cnu3Wbp29CMlB00eHtuNglzgQo';
-  static const String android = 'AIzaSyC2Q0duKwqkHEyGlIH6nGe-_ae6qXgb43Y';
+  static const String web = 'YOUR_GOOGLE_MAPS_API_KEY_WEB';
+  static const String android = 'YOUR_GOOGLE_MAPS_API_KEY_ANDROID';
   static const String ios = 'YOUR_GOOGLE_MAPS_API_KEY_IOS';
   static const String fallback = 'YOUR_GOOGLE_MAPS_API_KEY';
 }


### PR DESCRIPTION
## Summary
- use environment configuration for Google Maps API in `PlacesService`
- replace fallback Google Maps keys with placeholders
- replace Firebase API keys with placeholders

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763071bb6c832fbf6d38f7a4e42015