### PR TITLE
Fix item spacing in store prices page

### DIFF
--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -157,9 +157,10 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
           ),
         ],
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
           Padding(
             padding: const EdgeInsets.all(AppTheme.paddingMedium),
             child: Text(data['address'] ?? ''),
@@ -258,9 +259,17 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                     }).toList(),
                   ),
                 ),
+              final bottomPadding =
+                  MediaQuery.of(context).padding.bottom + kToolbarHeight;
+
               Expanded(
                 child: ListView.builder(
-                  padding: const EdgeInsets.all(AppTheme.paddingMedium),
+                  padding: EdgeInsets.fromLTRB(
+                    AppTheme.paddingMedium,
+                    AppTheme.paddingMedium,
+                    AppTheme.paddingMedium,
+                    bottomPadding,
+                  ),
                   itemCount: prices.length,
                   itemBuilder: (context, index) {
                     final doc = prices[index];
@@ -287,15 +296,18 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                           )
                         : null;
 
-                    return ListTile(
-                      leading: ClipRRect(
-                        borderRadius: BorderRadius.circular(AppTheme.radiusSmall),
-                        child: AppCachedImage(
-                          imageUrl: imageUrl,
-                          width: 56,
-                          height: 56,
+                    return Card(
+                      margin:
+                          const EdgeInsets.only(bottom: AppTheme.paddingSmall),
+                      child: ListTile(
+                        leading: ClipRRect(
+                          borderRadius: BorderRadius.circular(AppTheme.radiusSmall),
+                          child: AppCachedImage(
+                            imageUrl: imageUrl,
+                            width: 56,
+                            height: 56,
+                          ),
                         ),
-                      ),
                       title: Text(label),
                       trailing: Column(
                         mainAxisSize: MainAxisSize.min,
@@ -382,7 +394,7 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                           ),
                         );
                       },
-                    );
+                    ));
                   },
                 ),
               ),
@@ -391,7 +403,8 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
         },
       ),
           ),
-        ],
+          ],
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         heroTag: 'store_prices_fab',


### PR DESCRIPTION
## Summary
- wrap prices list in SafeArea
- pad list bottom to avoid clipping under FAB
- separate each price item with a card margin

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68777869c498832f93109c446a88c61b