### PR TITLE
Mark previous prices inactive on insert

### DIFF
--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -134,6 +134,7 @@ class InvoiceImportService {
       'product_name': productData['name'],
       'image_url': productData['image_url'],
       'status': ModerationStatus.approved.value,
+      'is_active': true,
       if (storeData['latitude'] != null)
         'latitude': (storeData['latitude'] as num).toDouble(),
       if (storeData['longitude'] != null)

--- a/lib/domain/entities/price.dart
+++ b/lib/domain/entities/price.dart
@@ -16,6 +16,7 @@ class Price extends Equatable {
   final DateTime? expiresAt;
   final ModerationStatus status;
   final DateTime updatedAt;
+  final bool isActive;
   final String? notes;
   final bool isPromotional;
   final DateTime? promotionalUntil;
@@ -44,6 +45,7 @@ class Price extends Equatable {
     this.expiresAt,
     required this.status,
     required this.updatedAt,
+    this.isActive = true,
     this.notes,
     required this.isPromotional,
     this.promotionalUntil,
@@ -73,6 +75,7 @@ class Price extends Equatable {
     DateTime? expiresAt,
     ModerationStatus? status,
     DateTime? updatedAt,
+    bool? isActive,
     String? notes,
     bool? isPromotional,
     DateTime? promotionalUntil,
@@ -101,6 +104,7 @@ class Price extends Equatable {
       expiresAt: expiresAt ?? this.expiresAt,
       status: status ?? this.status,
       updatedAt: updatedAt ?? this.updatedAt,
+      isActive: isActive ?? this.isActive,
       notes: notes ?? this.notes,
       isPromotional: isPromotional ?? this.isPromotional,
       promotionalUntil: promotionalUntil ?? this.promotionalUntil,
@@ -148,6 +152,7 @@ class Price extends Equatable {
         expiresAt,
         status,
         updatedAt,
+        isActive,
         notes,
         isPromotional,
         promotionalUntil,

--- a/lib/presentation/pages/feed/feed_page.dart
+++ b/lib/presentation/pages/feed/feed_page.dart
@@ -114,6 +114,7 @@ class _FeedPageState extends ConsumerState<FeedPage> {
     Query query = FirebaseFirestore.instance
         .collection('prices')
         .where('status', isEqualTo: ModerationStatus.approved.value)
+        .where('is_active', isEqualTo: true)
         .orderBy('created_at', descending: true)
         .limit(20);
     if (_lastDoc != null) {

--- a/lib/presentation/pages/price/add_price_page.dart
+++ b/lib/presentation/pages/price/add_price_page.dart
@@ -232,6 +232,22 @@ class _AddPricePageState extends State<AddPricePage> {
           FirebaseLogger.log('Nearby average error', {'error': e.toString()});
         }
 
+        try {
+          final prev = await FirebaseFirestore.instance
+              .collection('prices')
+              .where('product_id', isEqualTo: _selectedProduct!.id)
+              .where('store_id', isEqualTo: _selectedStore!.id)
+              .where('is_active', isEqualTo: true)
+              .orderBy('created_at', descending: true)
+              .limit(1)
+              .get();
+          if (prev.docs.isNotEmpty) {
+            await prev.docs.first.reference.update({'is_active': false});
+          }
+        } catch (e) {
+          FirebaseLogger.log('Deactivate price error', {'error': e.toString()});
+        }
+
         final data = {
           'product_id': _selectedProduct!.id,
           'product_name': productData['name'],
@@ -240,6 +256,7 @@ class _AddPricePageState extends State<AddPricePage> {
           'user_id': FirebaseAuth.instance.currentUser?.uid,
           'price': priceValue,
           'image_url': null,
+          'is_active': true,
           'created_at': Timestamp.now(),
           'expires_at': Timestamp.fromDate(
             DateTime.now().add(

--- a/lib/presentation/pages/price/price_search_page.dart
+++ b/lib/presentation/pages/price/price_search_page.dart
@@ -149,6 +149,7 @@ class _PriceSearchPageState extends State<PriceSearchPage> {
   Query _buildQuery() {
     return FirebaseFirestore.instance
         .collection('prices')
+        .where('is_active', isEqualTo: true)
         .orderBy('created_at', descending: true);
   }
 }

--- a/lib/presentation/pages/product/product_prices_page.dart
+++ b/lib/presentation/pages/product/product_prices_page.dart
@@ -152,6 +152,7 @@ class _ProductPricesPageState extends ConsumerState<ProductPricesPage> {
                   .where('product_id', isEqualTo: widget.product.id)
                   .where('status',
                       isEqualTo: ModerationStatus.approved.value)
+                  .where('is_active', isEqualTo: true)
                   .orderBy('price')
                   .orderBy('created_at', descending: true)
                   .snapshots(),

--- a/lib/presentation/pages/shopping_list/shopping_list_detail_page.dart
+++ b/lib/presentation/pages/shopping_list/shopping_list_detail_page.dart
@@ -105,6 +105,7 @@ class _ShoppingListDetailPageState extends ConsumerState<ShoppingListDetailPage>
               .where('store_id', isEqualTo: store.id)
               .where('status',
                   isEqualTo: ModerationStatus.approved.value)
+              .where('is_active', isEqualTo: true)
               .orderBy('created_at', descending: true)
               .limit(1)
               .get();
@@ -164,6 +165,7 @@ class _ShoppingListDetailPageState extends ConsumerState<ShoppingListDetailPage>
             .where('store_id', isEqualTo: store.id)
             .where('status',
                 isEqualTo: ModerationStatus.approved.value)
+            .where('is_active', isEqualTo: true)
             .orderBy('created_at', descending: true)
             .limit(1)
             .get();

--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -186,6 +186,7 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                   .where('store_id', isEqualTo: widget.store.id)
                   .where('status',
                       isEqualTo: ModerationStatus.approved.value)
+                  .where('is_active', isEqualTo: true)
                   .orderBy('price')
                   .orderBy('created_at', descending: true)
                   .snapshots(),

--- a/test/price_entity_test.dart
+++ b/test/price_entity_test.dart
@@ -21,6 +21,8 @@ void main() {
 
     final updated = price.copyWith(value: 12);
     expect(updated.value, 12);
+    expect(price.isActive, isTrue);
+    expect(price.copyWith(isActive: false).isActive, isFalse);
 
     expect(price.hasImage, isFalse);
     expect(price.formattedValue, 'R\$ 10,00');


### PR DESCRIPTION
## Summary
- add `isActive` property to `Price` entity
- deactivate older prices on new price creation
- ensure invoice import marks price active
- fetch only active prices in various queries
- add tests for price activation state

## Testing
- `flutter test test/price_entity_test.dart -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687778b297ec832f838982e21881cf2c