### PR TITLE
Allow HTML files for invoice import

### DIFF
--- a/lib/presentation/pages/admin/import_invoice_page.dart
+++ b/lib/presentation/pages/admin/import_invoice_page.dart
@@ -21,7 +21,8 @@ class _ImportInvoicePageState extends State<ImportInvoicePage> {
   Future<void> _pickFile() async {
     final result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
-      allowedExtensions: ['html', 'htm', 'xml'],
+      // Permit both lower and upper case extensions
+      allowedExtensions: ['html', 'HTML', 'htm', 'HTM', 'xml'],
       withData: true,
     );
     if (result != null) {


### PR DESCRIPTION
## Summary
- allow HTML/HTM uppercase extensions on invoice import picker

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687833138c3c832fa7fad68ad64401b1