### PR TITLE
Show average price indicator

### DIFF
--- a/lib/presentation/pages/feed/feed_page.dart
+++ b/lib/presentation/pages/feed/feed_page.dart
@@ -8,6 +8,7 @@ import '../../../core/constants/enums.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/shopping_list_provider.dart';
 import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
+import 'package:precinho_app/presentation/widgets/avg_comparison_icon.dart';
 import '../price/price_detail_page.dart';
 import '../invoice/invoice_qr_page.dart';
 import '../auth/login_page.dart';
@@ -422,6 +423,9 @@ class _FeedPageState extends ConsumerState<FeedPage> {
                                       ),
                                     ],
                                   ),
+                                AvgComparisonIcon(
+                                    comparison:
+                                        data['avg_comparison'] as String?),
                                 if ((data['expires_at'] as Timestamp?) != null &&
                                     DateTime.now().isAfter(
                                         (data['expires_at'] as Timestamp).toDate()))

--- a/lib/presentation/pages/price/price_detail_page.dart
+++ b/lib/presentation/pages/price/price_detail_page.dart
@@ -7,6 +7,7 @@ import 'add_price_page.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:http/http.dart' as http;
 import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
+import 'package:precinho_app/presentation/widgets/avg_comparison_icon.dart';
 import 'package:geolocator/geolocator.dart';
 
 class PriceDetailPage extends StatelessWidget {
@@ -251,6 +252,8 @@ class PriceDetailPage extends StatelessWidget {
                       ),
                     ],
                   ),
+                AvgComparisonIcon(
+                    comparison: data['avg_comparison'] as String?),
                 const SizedBox(height: AppTheme.paddingLarge),
                 Row(
                   children: [

--- a/lib/presentation/pages/price/price_search_page.dart
+++ b/lib/presentation/pages/price/price_search_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import '../../../core/themes/app_theme.dart';
 import '../../../core/utils/formatters.dart';
 import 'price_detail_page.dart';
+import 'package:precinho_app/presentation/widgets/avg_comparison_icon.dart';
 
 class PriceSearchPage extends StatefulWidget {
   const PriceSearchPage({super.key});
@@ -108,6 +109,8 @@ class _PriceSearchPageState extends State<PriceSearchPage> {
                                 ),
                               ],
                             ),
+                          AvgComparisonIcon(
+                              comparison: data['avg_comparison'] as String?),
                           if ((data['expires_at'] as Timestamp?) != null &&
                               DateTime.now().isAfter(
                                   (data['expires_at'] as Timestamp).toDate()))

--- a/lib/presentation/pages/price/user_prices_page.dart
+++ b/lib/presentation/pages/price/user_prices_page.dart
@@ -8,6 +8,7 @@ import '../../../core/utils/formatters.dart';
 import '../../providers/auth_provider.dart';
 import 'price_detail_page.dart';
 import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
+import 'package:precinho_app/presentation/widgets/avg_comparison_icon.dart';
 
 class UserPricesPage extends ConsumerWidget {
   const UserPricesPage({super.key});
@@ -47,6 +48,7 @@ class UserPricesPage extends ConsumerWidget {
               final expiresAt =
                   (data['expires_at'] as Timestamp?)?.toDate();
               final expired = expiresAt != null && DateTime.now().isAfter(expiresAt);
+              final isActive = data['is_active'] as bool? ?? true;
               return ListTile(
                 leading: AppCachedImage(
                   imageUrl: imageUrl,
@@ -62,8 +64,15 @@ class UserPricesPage extends ConsumerWidget {
                       data['price'] != null
                           ? Formatters.formatPrice((data['price'] as num).toDouble())
                           : '-',
-                      style: AppTheme.priceTextStyle,
+                      style: AppTheme.priceTextStyle.copyWith(
+                        decoration: isActive ? null : TextDecoration.lineThrough,
+                        color:
+                            isActive ? AppTheme.primaryColor : AppTheme.textDisabledColor,
+                      ),
                     ),
+                    const SizedBox(width: 4),
+                    AvgComparisonIcon(
+                        comparison: data['avg_comparison'] as String?),
                     if (expired)
                       IconButton(
                         icon: const Icon(Icons.warning,

--- a/lib/presentation/pages/product/product_prices_page.dart
+++ b/lib/presentation/pages/product/product_prices_page.dart
@@ -11,6 +11,7 @@ import '../price/add_price_page.dart';
 import '../price/price_detail_page.dart';
 import 'product_detail_page.dart';
 import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
+import 'package:precinho_app/presentation/widgets/avg_comparison_icon.dart';
 
 class ProductPricesPage extends ConsumerStatefulWidget {
   final DocumentSnapshot product;
@@ -305,8 +306,11 @@ class _ProductPricesPageState extends ConsumerState<ProductPricesPage> {
                                           fontSize: 12,
                                         ),
                                       ),
-                                    ],
-                                  ),
+                                  ],
+                                ),
+                                AvgComparisonIcon(
+                                    comparison:
+                                        priceData['avg_comparison'] as String?),
                                 if ((priceData['expires_at'] as Timestamp?) !=
                                         null &&
                                     DateTime.now().isAfter((priceData['expires_at']

--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -11,6 +11,7 @@ import '../price/add_price_page.dart';
 import '../price/price_detail_page.dart';
 import 'store_detail_page.dart';
 import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
+import 'package:precinho_app/presentation/widgets/avg_comparison_icon.dart';
 
 class StorePricesPage extends ConsumerStatefulWidget {
   final DocumentSnapshot store;
@@ -348,6 +349,8 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                                 ),
                               ],
                             ),
+                          AvgComparisonIcon(
+                              comparison: priceData['avg_comparison'] as String?),
                           if ((priceData['expires_at'] as Timestamp?) != null &&
                               DateTime.now().isAfter(
                                   (priceData['expires_at'] as Timestamp).toDate()))

--- a/lib/presentation/widgets/avg_comparison_icon.dart
+++ b/lib/presentation/widgets/avg_comparison_icon.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+import '../../core/themes/app_theme.dart';
+
+class AvgComparisonIcon extends StatelessWidget {
+  final String? comparison;
+  const AvgComparisonIcon({Key? key, required this.comparison}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    IconData icon;
+    Color color;
+    if (comparison == 'above_10') {
+      icon = Icons.trending_up;
+      color = AppTheme.errorColor;
+    } else if (comparison == 'below_10') {
+      icon = Icons.trending_down;
+      color = AppTheme.successColor;
+    } else {
+      icon = Icons.trending_flat;
+      color = AppTheme.infoColor;
+    }
+    return Icon(icon, color: color, size: 16);
+  }
+}


### PR DESCRIPTION
## Summary
- add AvgComparisonIcon widget
- display average comparison icons on price cards and details
- mark inactive prices in user list

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68784b9124c0832fb62c1c4408d0ea46