### PR TITLE
Fix invoice download 403

### DIFF
--- a/lib/presentation/pages/admin/import_invoice_page.dart
+++ b/lib/presentation/pages/admin/import_invoice_page.dart
@@ -69,7 +69,14 @@ class _ImportInvoicePageState extends State<ImportInvoicePage> {
     if (link.isEmpty) return;
     setState(() => _message = null);
     try {
-      final response = await http.get(Uri.parse(link));
+      final response = await http.get(
+        Uri.parse(link),
+        headers: const {
+          'User-Agent':
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0 Safari/537.36',
+          'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        },
+      );
       if (response.statusCode == 200) {
         final msg = await InvoiceHtmlParser.importInvoice(
           response.body,


### PR DESCRIPTION
## Summary
- mitigate 403 error by sending a browser-like user agent when downloading invoice HTML

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68784d57a880832fa8a11268b4e19271