### PR TITLE
Ensure only active prices are shown

### DIFF
--- a/lib/presentation/pages/price/price_detail_page.dart
+++ b/lib/presentation/pages/price/price_detail_page.dart
@@ -104,6 +104,7 @@ class PriceDetailPage extends StatelessWidget {
     final snap = await FirebaseFirestore.instance
         .collection('prices')
         .where('product_id', isEqualTo: productId)
+        .where('is_active', isEqualTo: true)
         .orderBy('created_at', descending: true)
         .limit(50)
         .get();
@@ -276,10 +277,11 @@ class PriceDetailPage extends StatelessWidget {
                 ),
                 const SizedBox(height: AppTheme.paddingSmall),
                 StreamBuilder<QuerySnapshot>(
-                  stream: FirebaseFirestore.instance
+              stream: FirebaseFirestore.instance
                       .collection('prices')
                       .where('product_id', isEqualTo: data['product_id'])
                       .where('store_id', isEqualTo: data['store_id'])
+                      .where('is_active', isEqualTo: true)
                       .orderBy('created_at', descending: true)
                       .limit(10)
                       .snapshots(),

--- a/lib/presentation/pages/price/user_prices_page.dart
+++ b/lib/presentation/pages/price/user_prices_page.dart
@@ -23,6 +23,7 @@ class UserPricesPage extends ConsumerWidget {
     final stream = FirebaseFirestore.instance
         .collection('prices')
         .where('user_id', isEqualTo: user.id)
+        .where('is_active', isEqualTo: true)
         .orderBy('created_at', descending: true)
         .snapshots();
 


### PR DESCRIPTION
## Summary
- filter user prices stream by `is_active`
- only fetch active prices in price detail page queries

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68784fda0158832f8b21ab23d545dcc7