### PR TITLE
Remove created_at ordering

### DIFF
--- a/lib/presentation/pages/product/product_prices_page.dart
+++ b/lib/presentation/pages/product/product_prices_page.dart
@@ -153,7 +153,6 @@ class _ProductPricesPageState extends ConsumerState<ProductPricesPage> {
                   .where('product_id', isEqualTo: widget.product.id)
                   .where('is_active', isEqualTo: true)
                   .orderBy('price')
-                  .orderBy('created_at', descending: true)
                   .snapshots(),
               builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {

--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -188,7 +188,6 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                   .where('store_id', isEqualTo: widget.store.id)
                   .where('is_active', isEqualTo: true)
                   .orderBy('price')
-                  .orderBy('created_at', descending: true)
                   .snapshots(),
               builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {


### PR DESCRIPTION
## Summary
- avoid sorting prices by `created_at` in store and product price listings

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d05c9330832fa85be9d9c5ff77f0