### PR TITLE
Fix EAN parsing

### DIFF
--- a/lib/data/parsers/invoice_html_parser.dart
+++ b/lib/data/parsers/invoice_html_parser.dart
@@ -221,8 +221,11 @@ class InvoiceHtmlParser {
       for (int i = 0; i < nItens; i++) {
         final rawEan = i < eans.length ? eans[i].trim() : null;
         String? cleanEan = rawEan;
-        if (cleanEan != null && RegExp(r'[A-Za-z]').hasMatch(cleanEan)) {
-          cleanEan = null;
+        if (cleanEan != null) {
+          cleanEan = cleanEan.replaceAll(RegExp(r'\D'), '');
+          if (cleanEan.isEmpty || cleanEan.length < 8 || cleanEan.length > 14) {
+            cleanEan = null;
+          }
         }
         final isFractional = cleanEan == null;
       final ncm = i < ncms.length ? ncms[i] : null;


### PR DESCRIPTION
## Summary
- strip non-digits when parsing EAN codes
- ignore EANs that end up with invalid length

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68798201a638832f97894ed8f4ef58ad