### PR TITLE
Implement uniform product price card height

### DIFF
--- a/lib/core/themes/app_theme.dart
+++ b/lib/core/themes/app_theme.dart
@@ -278,5 +278,8 @@ class AppTheme {
   static const double radiusMedium = 8.0;
   static const double radiusLarge = 12.0;
   static const double radiusXLarge = 16.0;
+
+  // Altura padrão para cards de preços de produto
+  static const double productCardHeight = 120.0;
 }
 

--- a/lib/presentation/pages/feed/feed_page.dart
+++ b/lib/presentation/pages/feed/feed_page.dart
@@ -328,8 +328,10 @@ class _FeedPageState extends ConsumerState<FeedPage> {
               }
               final createdAt = (data['created_at'] as Timestamp?)?.toDate();
 
-              return Card(
-                child: InkWell(
+              return SizedBox(
+                height: AppTheme.productCardHeight,
+                child: Card(
+                  child: InkWell(
                   onTap: () {
                     Navigator.push(
                       context,

--- a/lib/presentation/pages/price/price_search_page.dart
+++ b/lib/presentation/pages/price/price_search_page.dart
@@ -71,8 +71,10 @@ class _PriceSearchPageState extends State<PriceSearchPage> {
                       return const SizedBox.shrink();
                     }
 
-                    return Card(
-                      child: ListTile(
+                    return SizedBox(
+                      height: AppTheme.productCardHeight,
+                      child: Card(
+                        child: ListTile(
                         title: Text(productName.isNotEmpty ? productName : 'Produto'),
                         subtitle: Text(storeName.isNotEmpty ? storeName : 'Comércio'),
                         trailing: Column(

--- a/lib/presentation/pages/product/product_prices_page.dart
+++ b/lib/presentation/pages/product/product_prices_page.dart
@@ -225,8 +225,10 @@ class _ProductPricesPageState extends ConsumerState<ProductPricesPage> {
               final createdAt =
                   (priceData['created_at'] as Timestamp?)?.toDate();
 
-              return Card(
-                child: InkWell(
+              return SizedBox(
+                height: AppTheme.productCardHeight,
+                child: Card(
+                  child: InkWell(
                   onTap: () {
                     Navigator.push(
                       context,

--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -315,10 +315,12 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                           )
                         : null;
 
-                    return Card(
-                      margin:
-                          const EdgeInsets.only(bottom: AppTheme.paddingSmall),
-                      child: ListTile(
+                    return SizedBox(
+                      height: AppTheme.productCardHeight,
+                      child: Card(
+                        margin: const EdgeInsets.only(
+                            bottom: AppTheme.paddingSmall),
+                        child: ListTile(
                         leading: ClipRRect(
                           borderRadius: BorderRadius.circular(AppTheme.radiusSmall),
                           child: AppCachedImage(


### PR DESCRIPTION
## Summary
- standardize height for product price cards via `AppTheme.productCardHeight`
- apply the new size in price search, store prices, product prices and feed pages

## Testing
- `flutter analyze` *(fails: flutter not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a3e174208832f8c3758d5a4842979