### PR TITLE
Handle price per unit

### DIFF
--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -131,16 +131,22 @@ class InvoiceImportService {
     final storeData = storeSnap.data() ?? <String, dynamic>{};
 
     // Calcula o preço por quilo ou litro considerando o volume do produto
+    // Quando a unidade for "unidade" ("un"), calcula o valor de uma unidade
     double? unitPrice;
     final volume = productData['volume'];
     final unit = productData['unit'];
     if (volume is num && unit is String) {
       final normalized = unit.toLowerCase();
       double multiplier;
-      if (normalized == 'kg' || normalized == 'l' || normalized == 'lt' || normalized == 'lt.') {
+      if (normalized == 'kg' ||
+          normalized == 'l' ||
+          normalized == 'lt' ||
+          normalized == 'lt.') {
         multiplier = 1;
       } else if (normalized == 'g' || normalized == 'ml') {
         multiplier = 1 / 1000;
+      } else if (normalized == 'un' || normalized == 'unidade') {
+        multiplier = 1;
       } else {
         multiplier = 1;
       }

--- a/lib/presentation/pages/admin/edit_product_page.dart
+++ b/lib/presentation/pages/admin/edit_product_page.dart
@@ -304,6 +304,8 @@ class _EditProductPageState extends State<EditProductPage> {
       multiplier = 1;
     } else if (normalized == 'g' || normalized == 'ml') {
       multiplier = 1 / 1000;
+    } else if (normalized == 'un' || normalized == 'unidade') {
+      multiplier = 1;
     } else {
       // Unidade desconhecida, nao recalcula
       return;


### PR DESCRIPTION
## Summary
- support `un` units in unit price calculation
- update admin product edit price recalculation for `un`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3e8d0ab8832f96002da5bc797b69