### PR TITLE
Handle store name field on price import and updates

### DIFF
--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -167,6 +167,7 @@ class InvoiceImportService {
       'discount': discount,
       'description': description,
       'product_name': productData['name'],
+      'store_name': storeData['name'],
       'image_url': productData['image_url'],
       'is_active': true,
       if (storeData['latitude'] != null)

--- a/lib/presentation/pages/store/edit_store_page.dart
+++ b/lib/presentation/pages/store/edit_store_page.dart
@@ -25,6 +25,7 @@ class _EditStorePageState extends State<EditStorePage> {
   double? _longitude;
   double? _initialLatitude;
   double? _initialLongitude;
+  String? _initialName;
   String? _placeId;
   
 
@@ -33,6 +34,7 @@ class _EditStorePageState extends State<EditStorePage> {
     super.initState();
     final data = widget.document.data() as Map<String, dynamic>;
     _nameController.text = data['name'] ?? '';
+    _initialName = _nameController.text;
     _addressController.text = data['address'] ?? '';
     _cnpjController.text = data['cnpj'] ?? '';
     _latitude = (data['latitude'] as num?)?.toDouble();
@@ -79,6 +81,19 @@ class _EditStorePageState extends State<EditStorePage> {
             batch.update(doc.reference, {
               'latitude': _latitude,
               'longitude': _longitude,
+            });
+          }
+          await batch.commit();
+        }
+        if (_nameController.text.trim() != (_initialName ?? '')) {
+          final snap = await FirebaseFirestore.instance
+              .collection('prices')
+              .where('store_id', isEqualTo: widget.document.id)
+              .get();
+          final batch = FirebaseFirestore.instance.batch();
+          for (final doc in snap.docs) {
+            batch.update(doc.reference, {
+              'store_name': _nameController.text.trim(),
             });
           }
           await batch.commit();


### PR DESCRIPTION
## Summary
- add `store_name` when importing prices
- propagate store name changes to existing prices when editing a store

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a451712fc832f86d8e42ad0966fd6