### PR TITLE
Use invoice emission date when importing prices

### DIFF
--- a/lib/data/datasources/invoice_import_service.dart
+++ b/lib/data/datasources/invoice_import_service.dart
@@ -124,6 +124,8 @@ class InvoiceImportService {
     required DocumentReference<Map<String, dynamic>> invoiceRef,
     required DocumentReference<Map<String, dynamic>> storeRef,
     required DocumentReference<Map<String, dynamic>> productRef,
+    /// Data de criação do preço. Se não informada, usa [DateTime.now()].
+    DateTime? createdAt,
   }) async {
     final productSnap = await productRef.get();
     final productData = productSnap.data() ?? <String, dynamic>{};
@@ -177,7 +179,7 @@ class InvoiceImportService {
       if (ncm != null) 'ncm_code': ncm,
       if (ean != null) 'ean_code': ean,
       if (customCode != null) 'custom_code': customCode,
-      'created_at': Timestamp.now(),
+      'created_at': Timestamp.fromDate(createdAt ?? DateTime.now()),
     };
     final doc = await _firestore.collection('prices').add(data);
     return doc;

--- a/lib/data/parsers/invoice_html_parser.dart
+++ b/lib/data/parsers/invoice_html_parser.dart
@@ -13,6 +13,33 @@ class InvoiceHtmlParser {
     ) ?? 0.0;
   }
 
+  /// Converte a data de emissao no formato
+  /// "dd/MM/yyyy HH:mm:ss-03:00" para [DateTime].
+  static DateTime? _parseEmissionDate(String text) {
+    final regex = RegExp(r'^(\\d{2})\\/(\\d{2})\\/(\\d{4})\\s+(\\d{2}:\\d{2}:\\d{2})(.*)\$');
+    final match = regex.firstMatch(text.trim());
+    if (match != null) {
+      final day = match.group(1);
+      final month = match.group(2);
+      final year = match.group(3);
+      final time = match.group(4);
+      final tz = match.group(5);
+      final iso = '$year-$month-${day}T$time$tz';
+      return DateTime.parse(iso);
+    }
+    final regex2 = RegExp(r'^(\\d{2})\\/(\\d{2})\\/(\\d{4})\\s+(\\d{2}:\\d{2}:\\d{2})\$');
+    final match2 = regex2.firstMatch(text.trim());
+    if (match2 != null) {
+      final day = match2.group(1);
+      final month = match2.group(2);
+      final year = match2.group(3);
+      final time = match2.group(4);
+      final iso = '$year-$month-${day}T$time';
+      return DateTime.parse(iso);
+    }
+    return null;
+  }
+
   /// Extrai campos de um contêiner com múltiplos `div.col`
   static Map<String, List<String>> _extractFromCols(Element container) {
     final data = <String, List<String>>{};
@@ -162,6 +189,9 @@ class InvoiceHtmlParser {
     final serie = campos['Série']?[0] ?? '';
     final numero = campos['Número']?[0] ?? '';
 
+    final emissaoStr = campos['Data de Emissão']?[0] ?? '';
+    final invoiceDate = _parseEmissionDate(emissaoStr) ?? DateTime.now();
+
     final cnpj = campos['CNPJ']?[0].replaceAll(RegExp(r'\D'), '') ?? '';
     final nome = campos['Nome / Razão Social']?.first ??
         campos['Razão Social']?.first ??
@@ -269,6 +299,7 @@ class InvoiceHtmlParser {
         invoiceRef: invoiceRef,
         storeRef: storeRef,
         productRef: productRef,
+        createdAt: invoiceDate,
       );
     }
 


### PR DESCRIPTION
## Summary
- parse the invoice "Data de Emissão" field
- allow passing a custom creation date to `createPrice`
- set price creation date to the invoice emission date when importing HTML invoices

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_687a4ff30730832fa53cc79ff61bafde