### PR TITLE
Add manual access key input

### DIFF
--- a/lib/presentation/pages/invoice/invoice_manual_key_page.dart
+++ b/lib/presentation/pages/invoice/invoice_manual_key_page.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/themes/app_theme.dart';
+import 'invoice_qr_confirm_page.dart';
+
+class InvoiceManualKeyPage extends ConsumerStatefulWidget {
+  const InvoiceManualKeyPage({super.key});
+
+  @override
+  ConsumerState<InvoiceManualKeyPage> createState() => _InvoiceManualKeyPageState();
+}
+
+class _InvoiceManualKeyPageState extends ConsumerState<InvoiceManualKeyPage> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _keyController = TextEditingController();
+
+  @override
+  void dispose() {
+    _keyController.dispose();
+    super.dispose();
+  }
+
+  String? _validate(String? value) {
+    if (value == null) return 'Chave obrigatória';
+    final clean = value.replaceAll(RegExp(r'\D'), '');
+    if (clean.length != 44) return 'Chave deve ter 44 dígitos';
+    return null;
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    final key = _keyController.text.replaceAll(RegExp(r'\D'), '');
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => InvoiceQrConfirmPage(qrLink: key),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Chave de Acesso')),
+      body: Padding(
+        padding: const EdgeInsets.all(AppTheme.paddingLarge),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _keyController,
+                keyboardType: TextInputType.number,
+                maxLength: 44,
+                decoration: const InputDecoration(
+                  labelText: 'Chave de Acesso',
+                ),
+                validator: _validate,
+              ),
+              const SizedBox(height: AppTheme.paddingLarge),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _submit,
+                  child: const Text('Confirmar'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/invoice/invoice_qr_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_page.dart
@@ -8,6 +8,7 @@ import 'package:audioplayers/audioplayers.dart';
 import '../../../core/themes/app_theme.dart';
 import '../home/home_page.dart';
 import 'invoice_qr_confirm_page.dart';
+import 'invoice_manual_key_page.dart';
 
 class InvoiceQrPage extends ConsumerStatefulWidget {
   const InvoiceQrPage({super.key});
@@ -118,6 +119,18 @@ class _InvoiceQrPageState extends ConsumerState<InvoiceQrPage> {
             ),
           ),
         ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        heroTag: 'manual_key_fab',
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => const InvoiceManualKeyPage(),
+            ),
+          );
+        },
+        child: const Icon(Icons.edit),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- enable entering invoice key manually
- show a floating action button on the QR scan page

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aea708510832fb5bc45a262dddab5