### PR TITLE
Centralize price cards

### DIFF
--- a/lib/presentation/pages/feed/feed_page.dart
+++ b/lib/presentation/pages/feed/feed_page.dart
@@ -9,6 +9,7 @@ import '../../providers/auth_provider.dart';
 import '../../providers/shopping_list_provider.dart';
 import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 import 'package:precinho_app/presentation/widgets/avg_comparison_icon.dart';
+import '../../widgets/price/feed_price_card.dart';
 import '../price/price_detail_page.dart';
 import '../invoice/invoice_qr_page.dart';
 import '../auth/login_page.dart';
@@ -328,150 +329,23 @@ class _FeedPageState extends ConsumerState<FeedPage> {
               }
               final createdAt = (data['created_at'] as Timestamp?)?.toDate();
 
-              return Card(
-                child: InkWell(
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => PriceDetailPage(price: doc),
-                      ),
-                    );
-                  },
-                  child: Padding(
-                    padding: const EdgeInsets.all(AppTheme.paddingSmall),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            ClipRRect(
-                              borderRadius:
-                                  BorderRadius.circular(AppTheme.radiusSmall),
-                              child: AppCachedImage(
-                                imageUrl: productImage,
-                                width: 56,
-                                height: 56,
-                              ),
-                            ),
-                            const SizedBox(width: AppTheme.paddingSmall),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(productLabel),
-                                  const SizedBox(height: 2),
-                                  Row(
-                                    children: [
-                                      if (storeImage != null && storeImage.isNotEmpty)
-                                        ClipOval(
-                                          child: AppCachedImage(
-                                            imageUrl: storeImage,
-                                            width: 20,
-                                            height: 20,
-                                          ),
-                                        ),
-                                      if (storeImage != null && storeImage.isNotEmpty)
-                                        const SizedBox(width: 4),
-                                      Expanded(
-                                        child: Text(
-                                          data['store_name'] ?? '',
-                                          overflow: TextOverflow.ellipsis,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ],
-                              ),
-                            ),
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.end,
-                              children: [
-                                Text(
-                                  Formatters.formatPrice((data['price'] as num).toDouble()),
-                                  style: AppTheme.priceTextStyle,
-                                ),
-                                if (perUnit != null)
-                                  Text(
-                                    perUnit,
-                                    style: Theme.of(context).textTheme.labelSmall,
-                                  ),
-                                if (data['variation'] != null)
-                                  Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      Icon(
-                                        (data['variation'] as num) > 0
-                                            ? Icons.arrow_upward
-                                            : Icons.arrow_downward,
-                                        color: (data['variation'] as num) > 0
-                                            ? AppTheme.errorColor
-                                            : AppTheme.successColor,
-                                        size: 14,
-                                      ),
-                                      const SizedBox(width: 2),
-                                      Text(
-                                        Formatters.formatPercentage(
-                                            ((data['variation'] as num).abs()).toDouble()),
-                                        style: TextStyle(
-                                          color: (data['variation'] as num) > 0
-                                              ? AppTheme.errorColor
-                                              : AppTheme.successColor,
-                                          fontSize: 12,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                AvgComparisonIcon(
-                                    comparison:
-                                        data['avg_comparison'] as String?),
-                                if ((data['expires_at'] as Timestamp?) != null &&
-                                    DateTime.now().isAfter(
-                                        (data['expires_at'] as Timestamp).toDate()))
-                                  IconButton(
-                                    icon: const Icon(Icons.warning,
-                                        color: AppTheme.warningColor, size: 20),
-                                    tooltip: 'Preço pode estar desatualizado',
-                                    onPressed: () {
-                                      ScaffoldMessenger.of(context).showSnackBar(
-                                        const SnackBar(
-                                          content: Text(
-                                              'Este preço pode estar desatualizado'),
-                                        ),
-                                      );
-                                    },
-                                    padding: EdgeInsets.zero,
-                                  ),
-                              ],
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: AppTheme.paddingSmall),
-                        Row(
-                          children: [
-                            if (createdAt != null)
-                              Text(
-                                Formatters.formatDate(createdAt),
-                                style: Theme.of(context).textTheme.bodySmall,
-                              ),
-                            const Spacer(),
-                            if (distance != null)
-                              Text(
-                                Formatters.formatDistance(distance),
-                                style: AppTheme.distanceTextStyle,
-                              ),
-                            const SizedBox(width: 4),
-                            IconButton(
-                              icon: const Icon(Icons.playlist_add),
-                              onPressed: () => _addToList(doc),
-                            ),
-                          ],
-                        )
-                      ],
+              return FeedPriceCard(
+                doc: doc,
+                productLabel: productLabel,
+                productImage: productImage,
+                storeImage: storeImage,
+                createdAt: createdAt,
+                distance: distance,
+                perUnit: perUnit,
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => PriceDetailPage(price: doc),
                     ),
-                  ),
-                ),
+                  );
+                },
+                onAdd: () => _addToList(doc),
               );
             },
           ),

--- a/lib/presentation/pages/product/product_prices_page.dart
+++ b/lib/presentation/pages/product/product_prices_page.dart
@@ -12,6 +12,7 @@ import '../price/price_detail_page.dart';
 import 'product_detail_page.dart';
 import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
 import 'package:precinho_app/presentation/widgets/avg_comparison_icon.dart';
+import '../../widgets/price/product_price_card.dart';
 
 class ProductPricesPage extends ConsumerStatefulWidget {
   final DocumentSnapshot product;
@@ -225,143 +226,28 @@ class _ProductPricesPageState extends ConsumerState<ProductPricesPage> {
               final createdAt =
                   (priceData['created_at'] as Timestamp?)?.toDate();
 
-              return Card(
-                child: InkWell(
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => PriceDetailPage(price: doc),
-                      ),
-                    );
-                  },
-                  child: Padding(
-                    padding: const EdgeInsets.all(AppTheme.paddingSmall),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            const Icon(
-                              Icons.store,
-                              color: AppTheme.primaryColor,
-                            ),
-                            const SizedBox(width: AppTheme.paddingSmall),
-                            Expanded(child: Text(storeName)),
-                            IconButton(
-                              icon: Icon(
-                                isFav ? Icons.star : Icons.star_border,
-                                color: isFav
-                                    ? Colors.amber
-                                    : AppTheme.textSecondaryColor,
-                              ),
-                              onPressed: storeId == null
-                                  ? null
-                                  : () {
-                                      ref
-                                          .read(storeFavoritesProvider.notifier)
-                                          .toggleFavorite(storeId);
-                                    },
-                            ),
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.end,
-                              children: [
-                                Text(
-                                  Formatters.formatPrice(
-                                      (priceData['price'] as num).toDouble()),
-                                  style: AppTheme.priceTextStyle,
-                                ),
-                                if (perUnit != null)
-                                  Text(
-                                    perUnit,
-                                    style:
-                                        Theme.of(context).textTheme.labelSmall,
-                                  ),
-                                if (priceData['variation'] != null)
-                                  Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      Icon(
-                                        (priceData['variation'] as num) > 0
-                                            ? Icons.arrow_upward
-                                            : Icons.arrow_downward,
-                                        color: (priceData['variation'] as num) > 0
-                                            ? AppTheme.errorColor
-                                            : AppTheme.successColor,
-                                        size: 14,
-                                      ),
-                                      const SizedBox(width: 2),
-                                      Text(
-                                        Formatters.formatPercentage(
-                                            ((priceData['variation'] as num)
-                                                    .abs())
-                                                .toDouble()),
-                                        style: TextStyle(
-                                          color:
-                                              (priceData['variation'] as num) > 0
-                                                  ? AppTheme.errorColor
-                                                  : AppTheme.successColor,
-                                          fontSize: 12,
-                                        ),
-                                      ),
-                                  ],
-                                ),
-                                AvgComparisonIcon(
-                                    comparison:
-                                        priceData['avg_comparison'] as String?),
-                                if ((priceData['expires_at'] as Timestamp?) !=
-                                        null &&
-                                    DateTime.now().isAfter((priceData['expires_at']
-                                            as Timestamp)
-                                        .toDate()))
-                                  IconButton(
-                                    icon: const Icon(
-                                      Icons.warning,
-                                      color: AppTheme.warningColor,
-                                      size: 20,
-                                    ),
-                                    tooltip:
-                                        'Preço pode estar desatualizado',
-                                    onPressed: () {
-                                      ScaffoldMessenger.of(context).showSnackBar(
-                                        const SnackBar(
-                                          content: Text(
-                                              'Este preço pode estar desatualizado'),
-                                        ),
-                                      );
-                                    },
-                                    padding: EdgeInsets.zero,
-                                  ),
-                              ],
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: AppTheme.paddingSmall),
-                        Row(
-                          children: [
-                            if (createdAt != null)
-                              Text(
-                                Formatters.formatDate(createdAt),
-                                style:
-                                    Theme.of(context).textTheme.bodySmall,
-                              ),
-                            const Spacer(),
-                            IconButton(
-                              icon: const Icon(Icons.playlist_add),
-                              onPressed: () => _addPriceToList(doc),
-                            ),
-                          ],
-                        ),
-                      ],
+              return ProductPriceCard(
+                doc: doc,
+                storeName: storeName,
+                storeId: storeId,
+                isFavorite: isFav,
+                perUnit: perUnit,
+                createdAt: createdAt,
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => PriceDetailPage(price: doc),
                     ),
-                  ),
-                ),
+                  );
+                },
+                onAdd: () => _addPriceToList(doc),
+                onToggleFavorite: () {
+                  if (storeId != null) {
+                    ref.read(storeFavoritesProvider.notifier).toggleFavorite(storeId);
+                  }
+                },
               );
-            },
-          );
-        },
-      ),
     ),
   ],
 ),

--- a/lib/presentation/widgets/price/feed_price_card.dart
+++ b/lib/presentation/widgets/price/feed_price_card.dart
@@ -1,0 +1,172 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../app_cached_image.dart';
+import '../avg_comparison_icon.dart';
+import '../../core/themes/app_theme.dart';
+import '../../core/utils/formatters.dart';
+
+class FeedPriceCard extends StatelessWidget {
+  final DocumentSnapshot doc;
+  final String productLabel;
+  final String? productImage;
+  final String? storeImage;
+  final DateTime? createdAt;
+  final double? distance;
+  final String? perUnit;
+  final VoidCallback? onTap;
+  final VoidCallback? onAdd;
+
+  const FeedPriceCard({
+    super.key,
+    required this.doc,
+    required this.productLabel,
+    this.productImage,
+    this.storeImage,
+    this.createdAt,
+    this.distance,
+    this.perUnit,
+    this.onTap,
+    this.onAdd,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final data = doc.data() as Map<String, dynamic>;
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(AppTheme.paddingSmall),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(AppTheme.radiusSmall),
+                    child: AppCachedImage(
+                      imageUrl: productImage,
+                      width: 56,
+                      height: 56,
+                    ),
+                  ),
+                  const SizedBox(width: AppTheme.paddingSmall),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(productLabel),
+                        const SizedBox(height: 2),
+                        Row(
+                          children: [
+                            if (storeImage != null && storeImage!.isNotEmpty)
+                              ClipOval(
+                                child: AppCachedImage(
+                                  imageUrl: storeImage!,
+                                  width: 20,
+                                  height: 20,
+                                ),
+                              ),
+                            if (storeImage != null && storeImage!.isNotEmpty)
+                              const SizedBox(width: 4),
+                            Expanded(
+                              child: Text(
+                                data['store_name'] ?? '',
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        Formatters.formatPrice((data['price'] as num).toDouble()),
+                        style: AppTheme.priceTextStyle,
+                      ),
+                      if (perUnit != null)
+                        Text(
+                          perUnit!,
+                          style: Theme.of(context).textTheme.labelSmall,
+                        ),
+                      if (data['variation'] != null)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              (data['variation'] as num) > 0
+                                  ? Icons.arrow_upward
+                                  : Icons.arrow_downward,
+                              color: (data['variation'] as num) > 0
+                                  ? AppTheme.errorColor
+                                  : AppTheme.successColor,
+                              size: 14,
+                            ),
+                            const SizedBox(width: 2),
+                            Text(
+                              Formatters.formatPercentage(
+                                  ((data['variation'] as num).abs()).toDouble()),
+                              style: TextStyle(
+                                color: (data['variation'] as num) > 0
+                                    ? AppTheme.errorColor
+                                    : AppTheme.successColor,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ],
+                        ),
+                      AvgComparisonIcon(
+                          comparison: data['avg_comparison'] as String?),
+                      if ((data['expires_at'] as Timestamp?) != null &&
+                          DateTime.now()
+                              .isAfter((data['expires_at'] as Timestamp).toDate()))
+                        IconButton(
+                          icon: const Icon(Icons.warning,
+                              color: AppTheme.warningColor, size: 20),
+                          tooltip: 'Preço pode estar desatualizado',
+                          onPressed: () {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Este preço pode estar desatualizado'),
+                              ),
+                            );
+                          },
+                          padding: EdgeInsets.zero,
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppTheme.paddingSmall),
+              Row(
+                children: [
+                  if (createdAt != null)
+                    Text(
+                      Formatters.formatDate(createdAt!),
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  const Spacer(),
+                  if (distance != null)
+                    Text(
+                      Formatters.formatDistance(distance!),
+                      style: AppTheme.distanceTextStyle,
+                    ),
+                  const SizedBox(width: 4),
+                  IconButton(
+                    icon: const Icon(Icons.playlist_add),
+                    onPressed: onAdd,
+                  ),
+                ],
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/price/product_price_card.dart
+++ b/lib/presentation/widgets/price/product_price_card.dart
@@ -1,0 +1,145 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../app_cached_image.dart';
+import '../avg_comparison_icon.dart';
+import '../../core/themes/app_theme.dart';
+import '../../core/utils/formatters.dart';
+
+class ProductPriceCard extends StatelessWidget {
+  final DocumentSnapshot doc;
+  final String storeName;
+  final String? storeId;
+  final bool isFavorite;
+  final String? perUnit;
+  final DateTime? createdAt;
+  final VoidCallback? onTap;
+  final VoidCallback? onAdd;
+  final VoidCallback? onToggleFavorite;
+
+  const ProductPriceCard({
+    super.key,
+    required this.doc,
+    required this.storeName,
+    this.storeId,
+    required this.isFavorite,
+    this.perUnit,
+    this.createdAt,
+    this.onTap,
+    this.onAdd,
+    this.onToggleFavorite,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final data = doc.data() as Map<String, dynamic>;
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(AppTheme.paddingSmall),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(
+                    Icons.store,
+                    color: AppTheme.primaryColor,
+                  ),
+                  const SizedBox(width: AppTheme.paddingSmall),
+                  Expanded(child: Text(storeName)),
+                  IconButton(
+                    icon: Icon(
+                      isFavorite ? Icons.star : Icons.star_border,
+                      color:
+                          isFavorite ? Colors.amber : AppTheme.textSecondaryColor,
+                    ),
+                    onPressed: storeId == null ? null : onToggleFavorite,
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        Formatters.formatPrice((data['price'] as num).toDouble()),
+                        style: AppTheme.priceTextStyle,
+                      ),
+                      if (perUnit != null)
+                        Text(
+                          perUnit!,
+                          style: Theme.of(context).textTheme.labelSmall,
+                        ),
+                      if (data['variation'] != null)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              (data['variation'] as num) > 0
+                                  ? Icons.arrow_upward
+                                  : Icons.arrow_downward,
+                              color: (data['variation'] as num) > 0
+                                  ? AppTheme.errorColor
+                                  : AppTheme.successColor,
+                              size: 14,
+                            ),
+                            const SizedBox(width: 2),
+                            Text(
+                              Formatters.formatPercentage(
+                                  ((data['variation'] as num).abs()).toDouble()),
+                              style: TextStyle(
+                                color: (data['variation'] as num) > 0
+                                    ? AppTheme.errorColor
+                                    : AppTheme.successColor,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ],
+                        ),
+                      AvgComparisonIcon(
+                          comparison: data['avg_comparison'] as String?),
+                      if ((data['expires_at'] as Timestamp?) != null &&
+                          DateTime.now()
+                              .isAfter((data['expires_at'] as Timestamp).toDate()))
+                        IconButton(
+                          icon: const Icon(
+                            Icons.warning,
+                            color: AppTheme.warningColor,
+                            size: 20,
+                          ),
+                          tooltip: 'Preço pode estar desatualizado',
+                          onPressed: () {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Este preço pode estar desatualizado'),
+                              ),
+                            );
+                          },
+                          padding: EdgeInsets.zero,
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppTheme.paddingSmall),
+              Row(
+                children: [
+                  if (createdAt != null)
+                    Text(
+                      Formatters.formatDate(createdAt!),
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  const Spacer(),
+                  IconButton(
+                    icon: const Icon(Icons.playlist_add),
+                    onPressed: onAdd,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract price card widgets
- use `FeedPriceCard` in feed page
- use `ProductPriceCard` in product prices page

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6fdf1500832f921394e12092a683