### PR TITLE
Fix product prices page widget closure and imports

### DIFF
--- a/lib/presentation/pages/product/product_prices_page.dart
+++ b/lib/presentation/pages/product/product_prices_page.dart
@@ -252,6 +252,7 @@ class _ProductPricesPageState extends ConsumerState<ProductPricesPage> {
           );
         },
       ),
+          ),
     ],
   ),
       floatingActionButton: FloatingActionButton(

--- a/lib/presentation/widgets/price/feed_price_card.dart
+++ b/lib/presentation/widgets/price/feed_price_card.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 
 import '../app_cached_image.dart';
 import '../avg_comparison_icon.dart';
-import '../../core/themes/app_theme.dart';
-import '../../core/utils/formatters.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/utils/formatters.dart';
 
 class FeedPriceCard extends StatelessWidget {
   final DocumentSnapshot doc;

--- a/lib/presentation/widgets/price/product_price_card.dart
+++ b/lib/presentation/widgets/price/product_price_card.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 
 import '../app_cached_image.dart';
 import '../avg_comparison_icon.dart';
-import '../../core/themes/app_theme.dart';
-import '../../core/utils/formatters.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/utils/formatters.dart';
 
 class ProductPriceCard extends StatelessWidget {
   final DocumentSnapshot doc;


### PR DESCRIPTION
## Summary
- fix relative imports for price widgets
- close Expanded widget in product prices page

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b7c9af1c4832f896d2d9e241acd24