### PR TITLE
Fix store price card layout

### DIFF
--- a/lib/presentation/pages/store/store_prices_page.dart
+++ b/lib/presentation/pages/store/store_prices_page.dart
@@ -10,8 +10,7 @@ import '../../providers/shopping_list_provider.dart';
 import '../price/add_price_page.dart';
 import '../price/price_detail_page.dart';
 import 'store_detail_page.dart';
-import 'package:precinho_app/presentation/widgets/app_cached_image.dart';
-import 'package:precinho_app/presentation/widgets/avg_comparison_icon.dart';
+import 'package:precinho_app/presentation/widgets/price/store_price_card.dart';
 
 class StorePricesPage extends ConsumerStatefulWidget {
   final DocumentSnapshot store;
@@ -315,98 +314,13 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                           )
                         : null;
 
-                    return Card(
-                      margin:
-                          const EdgeInsets.only(bottom: AppTheme.paddingSmall),
-                      child: ListTile(
-                        leading: ClipRRect(
-                          borderRadius: BorderRadius.circular(AppTheme.radiusSmall),
-                          child: AppCachedImage(
-                            imageUrl: imageUrl,
-                            width: 56,
-                            height: 56,
-                          ),
-                        ),
-                      title: Text(label),
-                      trailing: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.end,
-                        children: [
-                          Text(
-                            Formatters.formatPrice(
-                                (priceData['price'] as num).toDouble()),
-                            style: AppTheme.priceTextStyle,
-                          ),
-                          if (perUnit != null)
-                            Text(
-                              perUnit,
-                              style: Theme.of(context).textTheme.labelSmall,
-                            ),
-                          if (priceData['variation'] != null)
-                            Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Icon(
-                                  (priceData['variation'] as num) > 0
-                                      ? Icons.arrow_upward
-                                      : Icons.arrow_downward,
-                                  color: (priceData['variation'] as num) > 0
-                                      ? AppTheme.errorColor
-                                      : AppTheme.successColor,
-                                  size: 14,
-                                ),
-                                const SizedBox(width: 2),
-                                Text(
-                                  Formatters.formatPercentage(
-                                      ((priceData['variation'] as num).abs()).toDouble()),
-                                  style: TextStyle(
-                                    color: (priceData['variation'] as num) > 0
-                                        ? AppTheme.errorColor
-                                        : AppTheme.successColor,
-                                    fontSize: 12,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          AvgComparisonIcon(
-                              comparison: priceData['avg_comparison'] as String?),
-                          if ((priceData['expires_at'] as Timestamp?) != null &&
-                              DateTime.now().isAfter(
-                                  (priceData['expires_at'] as Timestamp).toDate()))
-                            IconButton(
-                              icon: const Icon(Icons.warning,
-                                  color: AppTheme.warningColor, size: 20),
-                              tooltip: 'Preço pode estar desatualizado',
-                              onPressed: () {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content:
-                                        Text('Este preço pode estar desatualizado'),
-                                  ),
-                                );
-                              },
-                              padding: EdgeInsets.zero,
-                            ),
-                          Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              if ((priceData['created_at'] as Timestamp?) != null)
-                                Padding(
-                                  padding: const EdgeInsets.only(right: 8),
-                                  child: Text(
-                                    Formatters.formatDate(
-                                        (priceData['created_at'] as Timestamp).toDate()),
-                                    style: Theme.of(context).textTheme.bodySmall,
-                                  ),
-                                ),
-                              IconButton(
-                                icon: const Icon(Icons.playlist_add),
-                                onPressed: () => _addPriceToList(doc),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
+                    return StorePriceCard(
+                      doc: doc,
+                      label: label,
+                      imageUrl: imageUrl,
+                      perUnit: perUnit,
+                      createdAt:
+                          (priceData['created_at'] as Timestamp?)?.toDate(),
                       onTap: () {
                         Navigator.push(
                           context,
@@ -415,7 +329,8 @@ class _StorePricesPageState extends ConsumerState<StorePricesPage> {
                           ),
                         );
                       },
-                    ));
+                      onAdd: () => _addPriceToList(doc),
+                    );
                   },
                 ),
               ),

--- a/lib/presentation/widgets/price/store_price_card.dart
+++ b/lib/presentation/widgets/price/store_price_card.dart
@@ -1,0 +1,135 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../app_cached_image.dart';
+import '../avg_comparison_icon.dart';
+import '../../../core/themes/app_theme.dart';
+import '../../../core/utils/formatters.dart';
+
+class StorePriceCard extends StatelessWidget {
+  final DocumentSnapshot doc;
+  final String label;
+  final String? imageUrl;
+  final String? perUnit;
+  final DateTime? createdAt;
+  final VoidCallback? onTap;
+  final VoidCallback? onAdd;
+
+  const StorePriceCard({
+    super.key,
+    required this.doc,
+    required this.label,
+    this.imageUrl,
+    this.perUnit,
+    this.createdAt,
+    this.onTap,
+    this.onAdd,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final data = doc.data() as Map<String, dynamic>;
+    return Card(
+      margin: const EdgeInsets.only(bottom: AppTheme.paddingSmall),
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(AppTheme.paddingSmall),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(AppTheme.radiusSmall),
+                    child: AppCachedImage(
+                      imageUrl: imageUrl,
+                      width: 56,
+                      height: 56,
+                    ),
+                  ),
+                  const SizedBox(width: AppTheme.paddingSmall),
+                  Expanded(child: Text(label)),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        Formatters.formatPrice((data['price'] as num).toDouble()),
+                        style: AppTheme.priceTextStyle,
+                      ),
+                      if (perUnit != null)
+                        Text(
+                          perUnit!,
+                          style: Theme.of(context).textTheme.labelSmall,
+                        ),
+                      if (data['variation'] != null)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              (data['variation'] as num) > 0
+                                  ? Icons.arrow_upward
+                                  : Icons.arrow_downward,
+                              color: (data['variation'] as num) > 0
+                                  ? AppTheme.errorColor
+                                  : AppTheme.successColor,
+                              size: 14,
+                            ),
+                            const SizedBox(width: 2),
+                            Text(
+                              Formatters.formatPercentage(
+                                  ((data['variation'] as num).abs()).toDouble()),
+                              style: TextStyle(
+                                color: (data['variation'] as num) > 0
+                                    ? AppTheme.errorColor
+                                    : AppTheme.successColor,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ],
+                        ),
+                      AvgComparisonIcon(
+                          comparison: data['avg_comparison'] as String?),
+                      if ((data['expires_at'] as Timestamp?) != null &&
+                          DateTime.now()
+                              .isAfter((data['expires_at'] as Timestamp).toDate()))
+                        IconButton(
+                          icon: const Icon(Icons.warning,
+                              color: AppTheme.warningColor, size: 20),
+                          tooltip: 'Preço pode estar desatualizado',
+                          onPressed: () {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Este preço pode estar desatualizado'),
+                              ),
+                            );
+                          },
+                          padding: EdgeInsets.zero,
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppTheme.paddingSmall),
+              Row(
+                children: [
+                  if (createdAt != null)
+                    Text(
+                      Formatters.formatDate(createdAt!),
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  const Spacer(),
+                  IconButton(
+                    icon: const Icon(Icons.playlist_add),
+                    onPressed: onAdd,
+                  ),
+                ],
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `StorePriceCard` widget for displaying store prices
- use `StorePriceCard` in store prices page so cards don't crop content

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687b7f98279c832fb0adf0b85f96d3a2