### PR TITLE
Add expiration date for imported prices

### DIFF
--- a/lib/data/parsers/invoice_html_parser.dart
+++ b/lib/data/parsers/invoice_html_parser.dart
@@ -1,6 +1,7 @@
 import 'package:html/parser.dart' as html_parser;
 import 'package:html/dom.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../core/constants/app_constants.dart';
 import '../datasources/invoice_import_service.dart';
 import '../exceptions/missing_store_location_exception.dart';
 import '../../core/constants/enums.dart';
@@ -306,6 +307,9 @@ class InvoiceHtmlParser {
         storeRef: storeRef,
         productRef: productRef,
         createdAt: invoiceDate,
+        expiresAt: invoiceDate.add(
+          const Duration(days: AppConstants.defaultPriceValidityDays),
+        ),
       );
     }
 


### PR DESCRIPTION
## Summary
- set default expiration when creating prices from invoice
- pass computed expiration to `createPrice`
- expose expiration control in invoice importer

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d9d986fa4832f9b0a822aeeb1cd9e