### PR TITLE
Expand price comparison radius and add unit price recalculation

### DIFF
--- a/lib/presentation/pages/admin/edit_product_page.dart
+++ b/lib/presentation/pages/admin/edit_product_page.dart
@@ -495,6 +495,21 @@ class _EditProductPageState extends State<EditProductPage> {
                 ),
                 validator: Validators.validateDescription,
               ),
+              const SizedBox(height: AppTheme.paddingMedium),
+              OutlinedButton(
+                onPressed: () async {
+                  final volume =
+                      double.tryParse(_volumeController.text.trim());
+                  await _recalculateUnitPrices(volume: volume, unit: _unit);
+                  if (mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                          content: Text('Preços unitários recalculados')),
+                    );
+                  }
+                },
+                child: const Text('Recalcular Preços Unitários'),
+              ),
               const SizedBox(height: AppTheme.paddingLarge),
               SizedBox(
                 width: double.infinity,

--- a/lib/presentation/pages/price/add_price_page.dart
+++ b/lib/presentation/pages/price/add_price_page.dart
@@ -60,7 +60,7 @@ class _AddPricePageState extends State<AddPricePage> {
       final snapshot =
           await FirebaseFirestore.instance.collection('stores').get();
 
-      const radiusInMeters = 1000.0; // 1km
+      const radiusInMeters = 10000.0; // 10km
       final nearby = <Map<String, dynamic>>[];
 
       for (final doc in snapshot.docs) {
@@ -200,7 +200,7 @@ class _AddPricePageState extends State<AddPricePage> {
                 .limit(50)
                 .get();
 
-            const radiusInMeters = 1000.0;
+            const radiusInMeters = 10000.0;
             var sum = 0.0;
             var count = 0;
             for (final doc in snap.docs) {

--- a/lib/presentation/pages/price/price_detail_page.dart
+++ b/lib/presentation/pages/price/price_detail_page.dart
@@ -109,7 +109,7 @@ class PriceDetailPage extends StatelessWidget {
         .limit(50)
         .get();
 
-    const radiusInMeters = 1000.0;
+    const radiusInMeters = 10000.0;
     final nearby = <Map<String, dynamic>>[];
     for (final doc in snap.docs) {
       if (doc.id == price.id) continue;
@@ -325,7 +325,7 @@ class PriceDetailPage extends StatelessWidget {
               ),
               const SizedBox(height: AppTheme.paddingLarge),
               Text(
-                'Preços próximos (1km)',
+                'Preços próximos (10km)',
                 style: Theme.of(context).textTheme.titleMedium,
               ),
               const SizedBox(height: AppTheme.paddingSmall),


### PR DESCRIPTION
## Summary
- search for nearby prices within a 10 km radius
- update text for nearby prices message
- allow admins to manually recalculate unit prices when editing products

## Testing
- `flutter format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687daa3498dc832fbff3691f37c98a46