### PR TITLE
Centralize invoice access key validation

### DIFF
--- a/lib/core/utils/validators.dart
+++ b/lib/core/utils/validators.dart
@@ -213,6 +213,37 @@ class Validators {
     return null;
   }
 
+  // Verifica se a chave de acesso da nota fiscal é válida
+  static bool isValidInvoiceAccessKey(String key) {
+    final clean = key.replaceAll(RegExp(r'\D'), '');
+    if (clean.length != 44) return false;
+    final digits = clean.split('').map(int.parse).toList();
+    var weight = 2;
+    var sum = 0;
+    for (var i = digits.length - 2; i >= 0; i--) {
+      sum += digits[i] * weight;
+      weight = weight == 9 ? 2 : weight + 1;
+    }
+    final mod = sum % 11;
+    final dv = mod == 0 || mod == 1 ? 0 : 11 - mod;
+    return dv == digits.last;
+  }
+
+  // Validação de chave de acesso de nota fiscal
+  static String? validateInvoiceAccessKey(String? key) {
+    if (key == null || key.isEmpty) {
+      return 'Chave obrigatória';
+    }
+    final clean = key.replaceAll(RegExp(r'\D'), '');
+    if (clean.length != 44) {
+      return 'Chave deve ter 44 dígitos';
+    }
+    if (!isValidInvoiceAccessKey(clean)) {
+      return 'Chave inválida';
+    }
+    return null;
+  }
+
   // Validação de CNPJ
   static String? validateCnpj(String? cnpj) {
     if (cnpj == null || cnpj.isEmpty) {

--- a/lib/presentation/pages/invoice/invoice_manual_key_page.dart
+++ b/lib/presentation/pages/invoice/invoice_manual_key_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/themes/app_theme.dart';
+import '../../../core/utils/validators.dart';
 import 'invoice_qr_confirm_page.dart';
 
 class InvoiceManualKeyPage extends ConsumerStatefulWidget {
@@ -22,10 +23,7 @@ class _InvoiceManualKeyPageState extends ConsumerState<InvoiceManualKeyPage> {
   }
 
   String? _validate(String? value) {
-    if (value == null) return 'Chave obrigatória';
-    final clean = value.replaceAll(RegExp(r'\D'), '');
-    if (clean.length != 44) return 'Chave deve ter 44 dígitos';
-    return null;
+    return Validators.validateInvoiceAccessKey(value);
   }
 
   Future<void> _submit() async {

--- a/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
+++ b/lib/presentation/pages/invoice/invoice_qr_confirm_page.dart
@@ -5,6 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../../../core/logging/firebase_logger.dart';
 import '../../../core/themes/app_theme.dart';
+import '../../../core/utils/validators.dart';
 import '../../providers/auth_provider.dart';
 import '../../../data/datasources/invoice_service.dart';
 import 'package:flutter/services.dart';
@@ -39,22 +40,8 @@ class _InvoiceQrConfirmPageState extends ConsumerState<InvoiceQrConfirmPage> {
     final match = RegExp(r'(\d{44})').firstMatch(data);
     if (match == null) return null;
     final key = match.group(0)!;
-    if (_validateAccessKey(key)) return key;
+    if (Validators.isValidInvoiceAccessKey(key)) return key;
     return null;
-  }
-
-  bool _validateAccessKey(String key) {
-    if (key.length != 44) return false;
-    final digits = key.split('').map(int.parse).toList();
-    var weight = 2;
-    var sum = 0;
-    for (var i = digits.length - 2; i >= 0; i--) {
-      sum += digits[i] * weight;
-      weight = weight == 9 ? 2 : weight + 1;
-    }
-    final mod = sum % 11;
-    final dv = mod == 0 || mod == 1 ? 0 : 11 - mod;
-    return dv == digits.last;
   }
 
   Future<void> _validateQr() async {

--- a/test/validators_test.dart
+++ b/test/validators_test.dart
@@ -22,5 +22,18 @@ void main() {
       expect(Validators.validateCpf('111.444.777-35'), isNull);
       expect(Validators.validateCpf('123.456.789-00'), isNotNull);
     });
+
+    test('isValidInvoiceAccessKey', () {
+      const validKey = '12345678901234567890123456789012345678901235';
+      const invalidKey = '12345678901234567890123456789012345678901234';
+      expect(Validators.isValidInvoiceAccessKey(validKey), isTrue);
+      expect(Validators.isValidInvoiceAccessKey(invalidKey), isFalse);
+    });
+
+    test('validateInvoiceAccessKey', () {
+      const validKey = '12345678901234567890123456789012345678901235';
+      expect(Validators.validateInvoiceAccessKey(validKey), isNull);
+      expect(Validators.validateInvoiceAccessKey('123'), isNotNull);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- add invoice access key validation helpers
- use validators in manual invoice page and QR confirm
- cover new validators with tests

## Testing
- `flutter test test/validators_test.dart -r compact` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dae8614a4832fb04838736e9689c6