### PR TITLE
Allow manual store name input

### DIFF
--- a/lib/presentation/pages/store/add_store_page.dart
+++ b/lib/presentation/pages/store/add_store_page.dart
@@ -103,7 +103,6 @@ class _AddStorePageState extends State<AddStorePage> {
             children: [
               TextFormField(
                 controller: _nameController,
-                readOnly: true,
                 decoration: const InputDecoration(
                   labelText: 'Nome do Local',
                   prefixIcon: Icon(Icons.store),

--- a/lib/presentation/pages/store/edit_store_page.dart
+++ b/lib/presentation/pages/store/edit_store_page.dart
@@ -148,7 +148,6 @@ class _EditStorePageState extends State<EditStorePage> {
             children: [
               TextFormField(
                 controller: _nameController,
-                readOnly: true,
                 decoration: const InputDecoration(
                   labelText: 'Nome do Local',
                   prefixIcon: Icon(Icons.store),


### PR DESCRIPTION
## Summary
- remove readonly flag from add/edit store name fields

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687db24a55c8832fadcf6a112630dea2